### PR TITLE
Handle translations for plurals

### DIFF
--- a/app/controllers/admin/languages_controller.rb
+++ b/app/controllers/admin/languages_controller.rb
@@ -79,6 +79,6 @@ class Admin::LanguagesController < Admin::AdminController
   end
 
   def set_translation
-    @translation = params[:translation].to_s
+    @translation = params[:translation]
   end
 end

--- a/app/models/language.rb
+++ b/app/models/language.rb
@@ -112,11 +112,18 @@ class Language < ActiveRecord::Base
   def lookup(locale, key, scope, options = {})
     keys = normalize_keys(locale, key, scope)
 
-    keys.reduce(translations) do |result, k|
+    value = keys.reduce(translations) do |result, k|
       return nil unless result.is_a?(Hash)
       return nil unless result.key?(k)
 
       result[k]
+    end
+
+    case value
+    when Hash
+      value.deep_symbolize_keys
+    else
+      value
     end
   end
 

--- a/app/views/admin/languages/edit.html.erb
+++ b/app/views/admin/languages/edit.html.erb
@@ -12,18 +12,27 @@
     <label for="translation"><%= @language.name %><br /><%= @key %></label>
   </h2>
 
-  <div class="form-group">
-    <%= text_area_tag :translation, @translation, rows: 10, class: "form-control" %>
-
-    <% if @key.ends_with?("_html") %>
-      <p>
-        <small>This text contains HTML, please be careful not to break it when translating.</small>
-      </p>
-      <p>
-        <small>Only translate things which appear to be visible text and not attributes of the HTML tags unless they're obviously to be translated such as <code>title</code> and <code>value</code> attributes. If you are in any doubt about what needs to be translated, please contact support.</small>
-      </p>
+  <% if @translation.is_a?(Hash) %>
+    <% @translation.each do |key, value| %>
+      <div class="form-group">
+        <%= label_tag key, nil, for: "translation_#{key}", class: "form-label" %>
+        <%= text_field_tag :"translation[#{key}]", value, tabindex: increment, class: "form-control", autocomplete: 'off' %>
+      </div>
     <% end %>
-  </div>
+  <% else %>
+    <div class="form-group">
+      <%= text_area_tag :translation, @translation, rows: 10, class: "form-control" %>
+
+      <% if @key.ends_with?("_html") %>
+        <p>
+          <small>This text contains HTML, please be careful not to break it when translating.</small>
+        </p>
+        <p>
+          <small>Only translate things which appear to be visible text and not attributes of the HTML tags unless they're obviously to be translated such as <code>title</code> and <code>value</code> attributes. If you are in any doubt about what needs to be translated, please contact support.</small>
+        </p>
+      <% end %>
+    </div>
+  <% end %>
 
   <%= submit_tag 'Save', class: 'button' %>
   <%= link_to 'Cancel', admin_language_path(@language.locale), class: 'button-secondary' %>

--- a/spec/models/language_spec.rb
+++ b/spec/models/language_spec.rb
@@ -250,7 +250,12 @@ RSpec.describe Language, type: :model do
   describe "#lookup" do
     let(:language) { FactoryBot.create(:language, :english, translations: translations) }
     let(:translations) do
-      { "en-GB" => { "header" => { "title" => "Welsh Petitions" } } }
+      {
+        "en-GB" => {
+          "header" => { "title" => "Welsh Petitions" },
+          "signature_count" => { "one" => "1 signature", "other" => "%{count} signatures" }
+        }
+      }
     end
 
     context "a nested key" do
@@ -278,6 +283,12 @@ RSpec.describe Language, type: :model do
         it "returns nil" do
           expect(language.lookup(:"en-GB", :title, :header, {})).to eq("Welsh Petitions")
         end
+      end
+    end
+
+    context "a key that returns a hash" do
+      it "returns a hash with symbol keys" do
+        expect(language.lookup(:"en-GB", :signature_count, [], {})).to eq(one: "1 signature", other: "%{count} signatures")
       end
     end
   end


### PR DESCRIPTION
Clicking the link in the frontend goes to the parent translation so if the returned value is a hash display a series of fields.