### PR TITLE
Don't require translation for rejected petitions

### DIFF
--- a/app/models/petition.rb
+++ b/app/models/petition.rb
@@ -639,9 +639,20 @@ class Petition < ActiveRecord::Base
         build_rejection(attributes)
       end
 
-      unless translated? || rejection.hide_petition?
-        errors.add :moderation, :translation_missing
-        return false
+      unless translated?
+        if english?
+          update_columns(
+            action_cy: action_en,
+            background_cy: background_en,
+            additional_details_cy: additional_details_en
+          )
+        else
+          update_columns(
+            action_en: action_cy,
+            background_en: background_cy,
+            additional_details_en: additional_details_cy
+          )
+        end
       end
 
       rejection.save

--- a/features/admin/moderator_responds_to_petition.feature
+++ b/features/admin/moderator_responds_to_petition.feature
@@ -78,18 +78,9 @@ Feature: Moderator respond to petition
   Scenario: Moderator rejects petition with a suitable reason code
     Given I am logged in as a moderator
     When I look at the next petition on my list
-    And the petition is translated
     And I reject the petition with a reason code "Not the Government/Senedd’s responsibility"
     Then the petition is not available for signing
     But the petition is still available for searching or viewing
-
-  Scenario: Moderator tries to reject a petition before translation
-    Given I am logged in as a moderator
-    When I look at the next petition on my list
-    And I reject the petition with a reason code "Not the Government/Senedd’s responsibility"
-    Then the petition should still be unmoderated
-    And the creator should not receive a notification email
-    And I should see "The petition must be fully translated first before being made public"
 
   @javascript
   Scenario: Moderator previews reason description


### PR DESCRIPTION
This is to reduce workload on the translation team - just copy the existing petition details across to the other language.