### PR TITLE
Pause referral or rejection for 24 hours after closing

### DIFF
--- a/app/jobs/refer_or_reject_petitions_job.rb
+++ b/app/jobs/refer_or_reject_petitions_job.rb
@@ -1,0 +1,7 @@
+class ReferOrRejectPetitionsJob < ApplicationJob
+  queue_as :high_priority
+
+  def perform(time)
+    Petition.refer_or_reject_petitions!(time.in_time_zone)
+  end
+end

--- a/app/views/petitions/_closed_petition_show.html.erb
+++ b/app/views/petitions/_closed_petition_show.html.erb
@@ -42,6 +42,14 @@
         <p class="secondary"><%= t(:"ui.petitions.referral_threshold.referred.link_html", link: @petition.abms_link) %></p>
       <% end %>
     </section>
+  <% else %>
+    <section class="referral-notice" aria-labelledby="referral-notice-heading">
+      <h2 id="referral-notice-heading">
+        <%= t(:"ui.petitions.referral_threshold.closed.heading") %>
+      </h2>
+
+      <p><%= t(:"ui.petitions.referral_threshold.closed.description", threshold: Site.formatted_threshold_for_referral) %></p>
+    </section>
   <% end %>
 
   <div class="signature-count">

--- a/app/views/petitions/search/result_items/_petition_result_for_facet_all.html.erb
+++ b/app/views/petitions/search/result_items/_petition_result_for_facet_all.html.erb
@@ -4,7 +4,11 @@
   <p><%= signature_count(:default, petition.signature_count) %></p>
 <% when "closed" %>
   <p><%= signature_count(:default, petition.signature_count) %></p>
-  <p><%= t(:"ui.petitions.search.results.items.facet_all.closed") %></p>
+  <% if petition.referred? %>
+    <p><%= t(:"ui.petitions.search.results.items.facet_all.referred") %></p>
+  <% else %>
+    <p><%= t(:"ui.petitions.search.results.items.facet_all.closed") %></p>
+  <% end %>
 <% when "completed" %>
   <p><%= signature_count(:default, petition.signature_count) %></p>
   <p><%= t(:"ui.petitions.search.results.items.facet_all.completed", date: short_date_format(petition.completed_at)) %></p>

--- a/config/locales/ui.cy-GB.yml
+++ b/config/locales/ui.cy-GB.yml
@@ -458,7 +458,8 @@ cy-GB:
             facet_all:
               rejected: Gwrthodwyd
               completed: Cwblhawyd gan y Pwyllgor Deisebau ar %{date}
-              closed: Cyfeiriwyd at y Pwyllgor Deisebau
+              closed: Ar gau am lofnodion newydd
+              referred: Cyfeiriwyd at y Pwyllgor Deisebau
             facet_debated:
               debated_date: Cynhaliwyd dadl ar %{date}
             facet_referred:
@@ -534,6 +535,9 @@ cy-GB:
           referral_threshold: Caiff pob deiseb â mwy na %{threshold} llofnod ei thrafod
             gan y Pwyllgor Deisebau ar ôl iddi orffen casglu llofnodion
           referral_waiting_time: i’r Pwyllgor Deisebau drafod y ddeiseb hon
+        closed:
+          heading: Ar gau am lofnodion newydd
+          description: Gwneir penderfyniad p’un ai i atgyfeirio neu wrthod y ddeiseb hon yn fuan - caiff pob deiseb sydd â mwy na %{threshold} llofnod ei thrafod gan y Pwyllgor Deisebau.
         referred:
           heading: Mae’r Pwyllgor Deisebau bellach yn ystyried y ddeiseb hon
           link_html: <a href="%{link}">Rhagor o wybodaeth am drafodaethau’r Pwyllgor

--- a/config/locales/ui.en-GB.yml
+++ b/config/locales/ui.en-GB.yml
@@ -455,7 +455,8 @@ en-GB:
             facet_all:
               rejected: Rejected
               completed: Completed by the Petitions Committee on %{date}
-              closed: Referred to the Petitions Committee
+              closed: Closed for new signatures
+              referred: Referred to the Petitions Committee
             facet_debated:
               debated_date: Debated on %{date}
             facet_referred:
@@ -533,10 +534,13 @@ en-GB:
             will be discussed by the Petitions Committee after they have finished
             collecting signatures
           referral_waiting_time: for the Petitions Committee to consider this petition
+        closed:
+          heading: Closed for new signatures
+          description: A decision on whether to refer or reject this petition will be made shortly - all petitions with more than  %{threshold} signatures will be discussed by the Petitions Committee.
         referred:
-          heading: This petition is now under consideration by the Petitions Committee
+          heading: This petition is now under consideration by the Petitions Committee
           link_html: <a href="%{link}">Find out about the Petitions Committee’s discussion of this petition</a>
-          referral_threshold: Petitions that collect more than %{threshold} signatures are discussed by the Petitions Committee
+          referral_threshold: Petitions that collect more than %{threshold} signatures are discussed by the Petitions Committee
         completed:
           heading: This petition was considered by the Petitions Committee
           link_html: <a href="%{link}">Find out about the Petitions Committee’s discussion of this petition</a>

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -33,6 +33,10 @@ every :day, at: '7.00am' do
   rake "wpets:petitions:close", output: nil
 end
 
+every :day, at: '7.05am' do
+  rake "wpets:petitions:refer_or_reject", output: nil
+end
+
 every :day, at: '7.15am' do
   rake "wpets:petitions:debated", output: nil
 end

--- a/features/arnold_searches_from_home_page.feature
+++ b/features/arnold_searches_from_home_page.feature
@@ -9,7 +9,7 @@ Background:
     And an open petition exists with action_en: "Uncle Bulgaria", additional_details: "The Wombles are here", action_cy: "Yncl Bwlgaria", additional_details_cy: "Mae'r Wombles yma", closed_at: "1 minute from now"
     And an open petition exists with action_en: "Common People", background: "The Wombles belong to us all", action_cy: "Pobl Gyffredin", background_cy: "Mae'r Wombles yn perthyn i ni i gyd", closed_at: "11 days from now"
     And an open petition exists with action_en: "Overthrow the Wombles", action_cy: "Goresgyn y Wombles", closed_at: "1 year from now"
-    And a closed petition exists with action_en: "The Wombles will rock Glasto", action_cy: "Bydd y Wombles yn siglo Glasto", closed_at: "1 minute ago"
+    And a referred petition exists with action_en: "The Wombles will rock Glasto", action_cy: "Bydd y Wombles yn siglo Glasto", closed_at: "1 minute ago"
     And a rejected petition exists with action_en: "Eavis vs the Wombles", action_cy: "Eavis vs y Wombles"
     And a hidden petition exists with action_en: "The Wombles are profane", action_cy: "Mae'r Wombles yn halogedig"
     And an open petition exists with action_en: "Wombles", action_cy: "Wombles", closed_at: "10 days from now"

--- a/lib/tasks/petitions.rake
+++ b/lib/tasks/petitions.rake
@@ -8,6 +8,14 @@ namespace :wpets do
       end
     end
 
+    desc "Add a task to the queue to refer or reject petitions at midnight"
+    task :close => :environment do
+      Task.run("wpets:petitions:refer_or_reject") do
+        time = Date.tomorrow.beginning_of_day
+        ReferOrRejectPetitionsJob.set(wait_until: time).perform_later(time.iso8601)
+      end
+    end
+
     desc "Add a task to the queue to validate petition counts"
     task :count => :environment do
       Task.run("wpets:petitions:count") do

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -177,7 +177,7 @@ FactoryBot.define do
 
     after(:build) do |petition, evaluator|
       if evaluator.referred
-        petition.referral_threshold_reached_at = petition.open_at + 2.month
+        petition.referral_threshold_reached_at = petition.open_at + 2.months
       end
 
       petition.closed_at ||= Site.closed_at_for_opening(petition.open_at)

--- a/spec/jobs/close_petitions_job_spec.rb
+++ b/spec/jobs/close_petitions_job_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe ClosePetitionsJob, type: :job do
       travel_back
     end
 
-    context "and the debate date has not passed" do
+    context "and the closing date has not passed" do
       let(:now) { "2016-12-28T07:00:00Z".in_time_zone }
 
       it "does not change the petition state" do
@@ -60,7 +60,7 @@ RSpec.describe ClosePetitionsJob, type: :job do
       end
     end
 
-    context "and the debate date has passed" do
+    context "and the closing date has passed" do
       let(:now) { "2016-12-29T07:00:00Z".in_time_zone }
 
       it "does change the petition state" do

--- a/spec/jobs/refer_or_reject_petitions_job_spec.rb
+++ b/spec/jobs/refer_or_reject_petitions_job_spec.rb
@@ -1,0 +1,149 @@
+require 'rails_helper'
+
+RSpec.describe ReferOrRejectPetitionsJob, type: :job do
+  let!(:petition) {
+    FactoryBot.create(:closed_petition, referred: referred, open_at: open_at, closed_at: nil)
+  }
+
+  around do |example|
+    travel_to(now)
+    example.run
+    travel_back
+  end
+
+  context "for a petition opened in the winter" do
+    let(:open_at) { "2015-12-29T10:00:00Z" }
+
+    context "when the closing date has just passed" do
+      let(:now) { "2016-06-29T07:05:00Z".in_time_zone }
+
+      context "and the petition reached the referral threshold" do
+        let(:referred) { true }
+
+        it "does not refer the petition" do
+          expect{
+            perform_enqueued_jobs {
+              described_class.perform_later(Date.tomorrow.beginning_of_day.iso8601)
+            }
+          }.not_to change {
+            petition.reload.referred_at
+          }.from(nil)
+        end
+      end
+
+      context "and the petition did not reach the referral threshold" do
+        let(:referred) { false }
+
+        it "does not reject the petition" do
+          expect{
+            perform_enqueued_jobs {
+              described_class.perform_later(Date.tomorrow.beginning_of_day.iso8601)
+            }
+          }.not_to change {
+            petition.reload.state
+          }.from("closed")
+        end
+      end
+    end
+
+    context "when the closing date has passed yesterday" do
+      let(:now) { "2016-06-30T07:05:00Z".in_time_zone }
+
+      context "and the petition reached the referral threshold" do
+        let(:referred) { true }
+
+        it "refers the petition" do
+          expect{
+            perform_enqueued_jobs {
+              described_class.perform_later(Date.tomorrow.beginning_of_day.iso8601)
+            }
+          }.to change {
+            petition.reload.referred_at
+          }.from(nil).to(Date.tomorrow.beginning_of_day)
+        end
+      end
+
+      context "and the petition did not reach the referral threshold" do
+        let(:referred) { false }
+
+        it "rejects the petition" do
+          expect{
+            perform_enqueued_jobs {
+              described_class.perform_later(Date.tomorrow.beginning_of_day.iso8601)
+            }
+          }.to change {
+            petition.reload.state
+          }.from("closed").to("rejected")
+        end
+      end
+    end
+  end
+
+  context "for a petition opened in the summer" do
+    let(:open_at) { "2016-06-29T10:00:00Z" }
+
+    context "when the closing date has just passed" do
+      let(:now) { "2016-12-29T07:05:00Z".in_time_zone }
+
+      context "and the petition reached the referral threshold" do
+        let(:referred) { true }
+
+        it "does not refer the petition" do
+          expect{
+            perform_enqueued_jobs {
+              described_class.perform_later(Date.tomorrow.beginning_of_day.iso8601)
+            }
+          }.not_to change {
+            petition.reload.referred_at
+          }.from(nil)
+        end
+      end
+
+      context "and the petition did not reach the referral threshold" do
+        let(:referred) { false }
+
+        it "does not reject the petition" do
+          expect{
+            perform_enqueued_jobs {
+              described_class.perform_later(Date.tomorrow.beginning_of_day.iso8601)
+            }
+          }.not_to change {
+            petition.reload.state
+          }.from("closed")
+        end
+      end
+    end
+
+    context "when the closing date has passed yesterday" do
+      let(:now) { "2016-12-30T07:05:00Z".in_time_zone }
+
+      context "and the petition reached the referral threshold" do
+        let(:referred) { true }
+
+        it "refers the petition" do
+          expect{
+            perform_enqueued_jobs {
+              described_class.perform_later(Date.tomorrow.beginning_of_day.iso8601)
+            }
+          }.to change {
+            petition.reload.referred_at
+          }.from(nil).to(Date.tomorrow.beginning_of_day)
+        end
+      end
+
+      context "and the petition did not reach the referral threshold" do
+        let(:referred) { false }
+
+        it "rejects the petition" do
+          expect{
+            perform_enqueued_jobs {
+              described_class.perform_later(Date.tomorrow.beginning_of_day.iso8601)
+            }
+          }.to change {
+            petition.reload.state
+          }.from("closed").to("rejected")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
We allow up to 24 hours for links in emails to be clicked and signatures validated as a consequence so we can't be 100% sure a petition has failed to reach the deadline until after this period.

These petitions will only be visible in the all petitions list and when accessed directly they display a holding message informing the user that a decision is pending.

### All petitions (English)

![image](https://user-images.githubusercontent.com/6321/81471413-c9110f00-91e8-11ea-9a94-f52fed3a9b01.png)

### All petitions (Welsh)

![image](https://user-images.githubusercontent.com/6321/81471425-efcf4580-91e8-11ea-9114-602066079a76.png)

### Petition (English)

![image](https://user-images.githubusercontent.com/6321/81471445-142b2200-91e9-11ea-8636-82c4666c0e7d.png)

### Petition (Welsh)

![image](https://user-images.githubusercontent.com/6321/81471451-1ee5b700-91e9-11ea-8d9f-5134f35d80fa.png)

