### PR TITLE
Allow petitions to be restored to the sponsored state

### DIFF
--- a/app/models/petition.rb
+++ b/app/models/petition.rb
@@ -635,7 +635,7 @@ class Petition < ActiveRecord::Base
   end
 
   def moderation=(value)
-    @moderation = value if value.in?(%w[approve reject flag unflag])
+    @moderation = value if value.in?(%w[approve reject restore flag unflag])
   end
 
   def moderation
@@ -701,7 +701,7 @@ class Petition < ActiveRecord::Base
         reject(params[:rejection])
       when 'flag'
         update(state: FLAGGED_STATE)
-      when 'unflag'
+      when 'unflag', 'restore'
         update(state: SPONSORED_STATE)
       else
         if flagged?
@@ -710,7 +710,7 @@ class Petition < ActiveRecord::Base
           errors.add :moderation, :blank, action: 'flag'
         end
 
-        return false
+        false
       end
     end
   end

--- a/app/views/admin/moderation/_form.html.erb
+++ b/app/views/admin/moderation/_form.html.erb
@@ -10,7 +10,12 @@
       <%= f.radio_button :moderation, 'approve' %>
       <%= f.label :moderation_approve, "Approve", for: "petition_moderation_approve" %>
     </div>
-    <% unless f.object.rejection? %>
+    <% if f.object.rejection? %>
+    <div class="multiple-choice">
+    <%= f.radio_button :moderation, 'restore' %>
+    <%= f.label :moderation_reject, "Restore", for: "petition_moderation_restore" %>
+    </div>
+    <% else %>
     <div class="multiple-choice">
     <%= f.radio_button :moderation, 'reject' %>
     <%= f.label :moderation_reject, "Reject", for: "petition_moderation_reject" %>

--- a/app/views/admin/petitions/_petition_content.html.erb
+++ b/app/views/admin/petitions/_petition_content.html.erb
@@ -34,7 +34,7 @@
   <%= link_to 'Welsh', admin_petition_details_path(@petition, locale: "cy-GB") %>
 </p>
 
-<% if @petition.rejected? or @petition.hidden? -%>
+<% if @petition.rejection? -%>
   <h2>This petition was rejected</h2>
   <p><%= rejection_reason(@petition.rejection.code) %></p>
 

--- a/features/admin/moderator_responds_to_petition.feature
+++ b/features/admin/moderator_responds_to_petition.feature
@@ -174,11 +174,31 @@ Feature: Moderator respond to petition
     When I revisit the petition
     Then the petition can no longer be rejected
     But it can still be approved
+    And it can still be restored
     And it can still be flagged
     When I publish the petition
     Then I should see "Published by Ben Macintosh"
     And the petition should be visible on the site for signing
     And the creator should receive a notification email
+
+  @javascript
+  Scenario: Moderator restores a rejected petition
+    Given I am logged in as a sysadmin named "Ben Macintosh"
+    When I look at the next petition on my list
+    And I reject the petition
+    Then the creator should receive a rejection notification email
+    And the petition is not available for signing
+    But the petition is still available for searching or viewing
+    Given no emails have been sent
+    When I revisit the petition
+    Then the petition can no longer be rejected
+    But it can still be approved
+    And it can still be restored
+    And it can still be flagged
+    When I restore the petition
+    Then the creator should not receive a notification email
+    And the petition is not available for searching or viewing
+    But the petition will still show up in the back-end reporting
 
   @javascript
   Scenario: Moderator flags a rejected petition
@@ -192,6 +212,7 @@ Feature: Moderator respond to petition
     When I revisit the petition
     Then the petition can no longer be rejected
     But it can still be approved
+    And it can still be restored
     And it can still be flagged
     When I flag the petition
     Then the creator should not receive a notification email

--- a/features/step_definitions/moderation_steps.rb
+++ b/features/step_definitions/moderation_steps.rb
@@ -49,6 +49,11 @@ When(/^I flag the petition$/) do
   click_button "Save without emailing"
 end
 
+When(/^I restore the petition$/) do
+  choose "Restore"
+  click_button "Save without emailing"
+end
+
 Then /^the petition is still available for searching or viewing$/ do
   step %{I search for "Rejected petitions" with "#{@petition.action}"}
   step %{I should see the petition "#{@petition.action}"}
@@ -213,6 +218,10 @@ end
 
 Then /^it can still be rejected$/ do
   expect(page).to have_field('Reject', visible: false)
+end
+
+Then(/^it can still be restored$/) do
+  expect(page).to have_field('Restore', visible: false)
 end
 
 Then /^it can be restored to a sponsored state$/ do


### PR DESCRIPTION
When petitions have been rejected the sometimes need to go back to 'sponsored' while further moderation checks are carried out. It was possible to do this via flag/unflag but this is more user-friendly.