### PR TITLE
Add additional sanitization to browseable params

### DIFF
--- a/app/controllers/petitions_controller.rb
+++ b/app/controllers/petitions_controller.rb
@@ -128,12 +128,16 @@ class PetitionsController < LocalizedController
     params[:state].present?
   end
 
+  def sanitized_state
+    params[:state].to_s[0..30].to_sym
+  end
+
   def valid_state?
     public_facet? || archived_facet?
   end
 
   def public_facet?
-    public_petition_facets.include?(params[:state].to_sym)
+    public_petition_facets.include?(sanitized_state)
   end
 
   def archived_facet?

--- a/app/models/concerns/browseable.rb
+++ b/app/models/concerns/browseable.rb
@@ -1,12 +1,21 @@
 module Browseable
   extend ActiveSupport::Concern
 
+  VALID_PAGE = /\A[1-9][0-9]{0,4}\z/
+  VALID_PAGE_SIZE = /\A(?:[1-9]|[1-5][0-9])\z/
+
   included do
     class_attribute :facet_definitions, instance_writer: false
     self.facet_definitions = {}
 
     class_attribute :filter_definitions, instance_writer: false
     self.filter_definitions = {}
+
+    class_attribute :default_page_size, instance_writer: false
+    self.default_page_size = 50
+
+    class_attribute :max_page_size, instance_writer: false
+    self.max_page_size = 50
   end
 
   class Facets
@@ -104,6 +113,7 @@ module Browseable
 
     attr_reader :klass, :params
 
+    delegate :default_page_size, :max_page_size, to: :klass
     delegate :offset, :out_of_bounds?, to: :results
     delegate :next_page, :previous_page, to: :results
     delegate :total_entries, :total_pages, to: :results
@@ -114,7 +124,7 @@ module Browseable
     end
 
     def current_page
-      @current_page ||= [params[:page].to_i, 1].max
+      @current_page ||= [sanitized_page, 1].max
     end
 
     def each(&block)
@@ -150,7 +160,7 @@ module Browseable
     end
 
     def page_size
-      @page_size ||= [[params.fetch(:count, 50).to_i, 50].min, 1].max
+      @page_size ||= [[sanitized_page_size, max_page_size].min, 1].max
     end
 
     def previous_params
@@ -233,6 +243,18 @@ module Browseable
 
     def star
       klass.arel_table[Arel.star]
+    end
+
+    def sanitize_param(value, pattern, default)
+      value.match?(pattern) ? Integer(value) : default
+    end
+
+    def sanitized_page
+      sanitize_param(params[:page].to_s, VALID_PAGE, 1)
+    end
+
+    def sanitized_page_size
+      sanitize_param(params[:count].to_s, VALID_PAGE_SIZE, default_page_size)
     end
   end
 

--- a/spec/controllers/petitions_controller_spec.rb
+++ b/spec/controllers/petitions_controller_spec.rb
@@ -334,6 +334,76 @@ RSpec.describe PetitionsController, type: :controller do
           expect(assigns(:petitions).scope).to eq :open
         end
       end
+
+      context "and it is an array" do
+        it "redirects to itself with state=all" do
+          get :index, params: { state: [ "l337haxxor" ] }
+          expect(response).to redirect_to "https://petitions.senedd.wales/petitions?state=all"
+        end
+
+        it "preserves other params when it redirects" do
+          get :index, params: { q: "what is clocks", state: [ "l337haxxor" ] }
+          expect(response).to redirect_to "https://petitions.senedd.wales/petitions?q=what+is+clocks&state=all"
+        end
+      end
+
+      context "and it is a hash" do
+        it "redirects to itself with state=all" do
+          get :index, params: { state: { l337: "haxxor" } }
+          expect(response).to redirect_to "https://petitions.senedd.wales/petitions?state=all"
+        end
+
+        it "preserves other params when it redirects" do
+          get :index, params: { q: "what is clocks", state: { l337: "haxxor" } }
+          expect(response).to redirect_to "https://petitions.senedd.wales/petitions?q=what+is+clocks&state=all"
+        end
+      end
+    end
+
+    context "when a page param is provided" do
+      context "and it is an array" do
+        it "is treated as being on the first page" do
+          get :index, params: { page: [ "l337haxxor" ] }
+          expect(assigns(:petitions).current_page).to eq 1
+        end
+      end
+
+      context "and it is a hash" do
+        it "is treated as being on the first page" do
+          get :index, params: { page: { l337: "haxxor" } }
+          expect(assigns(:petitions).current_page).to eq 1
+        end
+      end
+
+      context "and it is out of range" do
+        it "is treated as being on the first page" do
+          get :index, params: { page: "414141414141414141" }
+          expect(assigns(:petitions).current_page).to eq 1
+        end
+      end
+    end
+
+    context "when a count param is provided" do
+      context "and it is an array" do
+        it "uses the default count" do
+          get :index, params: { count: [ "l337haxxor" ] }
+          expect(assigns(:petitions).page_size).to eq 50
+        end
+      end
+
+      context "and it is a hash" do
+        it "uses the default count" do
+          get :index, params: { count: { l337: "haxxor" } }
+          expect(assigns(:petitions).page_size).to eq 50
+        end
+      end
+
+      context "and it is out of range" do
+        it "uses the default count" do
+          get :index, params: { count: "414141414141414141" }
+          expect(assigns(:petitions).page_size).to eq 50
+        end
+      end
     end
   end
 

--- a/spec/models/concerns/browseable_spec.rb
+++ b/spec/models/concerns/browseable_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Browseable, type: :model do
   describe Browseable::Search do
     let(:scopes)  { { all: -> { self }, open: -> { self } } }
     let(:filters) { {} }
-    let(:klass)   { double(:klass, facet_definitions: scopes, filter_definitions: filters) }
+    let(:klass)   { double(:klass, facet_definitions: scopes, filter_definitions: filters, default_page_size: 50, max_page_size: 50) }
     let(:params)  { { q: 'search', page: '3'} }
     let(:search)  { described_class.new(klass, params) }
 
@@ -265,16 +265,16 @@ RSpec.describe Browseable, type: :model do
       context "when the count param is set to zero" do
         let(:params) { { q: 'search', page: '1', count: '0' } }
 
-        it "returns 1" do
-          expect(search.page_size).to eq(1)
+        it "returns the default page size" do
+          expect(search.page_size).to eq(50)
         end
       end
 
       context "when the count param is set to less than 0" do
         let(:params) { { q: 'search', page: '1', count: '-10' } }
 
-        it "returns 1" do
-          expect(search.page_size).to eq(1)
+        it "returns the default page size" do
+          expect(search.page_size).to eq(50)
         end
       end
     end


### PR DESCRIPTION
Every now and again someone decides to run a tool like Acunetix across the website and whilst nothing bad happens the spike of Appsignal reports is annoying so prevent some of those 500 errors occurring.