### PR TITLE
Fix image validator

### DIFF
--- a/app/validators/image_validator.rb
+++ b/app/validators/image_validator.rb
@@ -18,8 +18,16 @@ class ImageValidator < ActiveModel::EachValidator
   private
 
   def read_image(record, attribute, attachment)
+    return unless record.attachment_changes.key?(attachment.name)
+
     changes = record.attachment_changes[attachment.name]
-    path = changes.attachable.tempfile.path
+    attachable = changes.attachable
+
+    if attachable.is_a?(Hash)
+      path = attachable[:io].path
+    else
+      path = attachable.tempfile.path
+    end
 
     image = MiniMagick::Image.new(path)
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -276,7 +276,7 @@ FactoryBot.define do
       debate_pack_url { nil }
       debate_pack_url_en { nil }
       debate_pack_url_cy { nil }
-      commons_image { nil }
+      debate_image { nil }
     end
 
     debate_state { 'debated' }
@@ -340,8 +340,8 @@ FactoryBot.define do
         debate_outcome_attributes[:debate_pack_url_cy] = evaluator.debate_pack_url_cy
       end
 
-      if evaluator.commons_image.present?
-        debate_outcome_attributes[:commons_image] = evaluator.commons_image
+      if evaluator.debate_image.present?
+        debate_outcome_attributes[:image] = evaluator.debate_image
       end
 
       petition.build_debate_outcome(debate_outcome_attributes)


### PR DESCRIPTION
When there are no changes we should not validate the image. Also support providing a hash for the attachable changes.