### PR TITLE
Prevent multiple emails when on sponsor threshold

### DIFF
--- a/features/charlie_is_notified_about_sponsors_signing_his_petition.feature
+++ b/features/charlie_is_notified_about_sponsors_signing_his_petition.feature
@@ -22,3 +22,13 @@ Feature: Charlie is notified to get an MP
     Given I have enough support from sponsors for my petition
     When a sponsor supports my petition
     Then I should not receive a sponsor support notification email
+
+  Scenario: Charlie is only notified once when Laura validates her signature multiple times
+    Given I only need one more sponsor to support my petition
+    And signature counting is handled by an external process
+    When Laura supports my petition
+    Then I should not receive a sponsor support notification email
+    But I should receive a sponsor threshold notification email
+    When Laura verifies her signature again
+    Then I should not receive a sponsor support notification email
+    And I should not receive a sponsor threshold notification email

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -14,6 +14,10 @@ Given(/^the site is protected$/) do
   Site.instance.update! protected: true, username: "username", password: "password"
 end
 
+Given(/^signature counting is handled by an external process$/) do
+  ENV["INLINE_UPDATES"] = "false"
+end
+
 Given(/^the request is not local$/) do
   page.driver.options[:headers] = { "REMOTE_ADDR" => "192.168.1.128" }
 end

--- a/features/step_definitions/sponsor_steps.rb
+++ b/features/step_definitions/sponsor_steps.rb
@@ -1,16 +1,14 @@
 Given(/^I have been told about a petition that needs sponsoring$/) do
-  @sponsor_petition = FactoryBot.create(:open_petition,
-    action: 'Charles to be nominated for sublimation',
-    closed_at: 1.day.from_now,
-    state: Petition::VALIDATED_STATE)
+  @sponsor_petition = FactoryBot.create(:validated_petition,
+    action: 'Charles to be nominated for sublimation'
+  )
 end
 
 Given(/^I have created a petition and told people to sponsor it$/) do
   @sponsor_petition = FactoryBot.create(:pending_petition,
     action: 'Charles to be nominated for sublimation',
-    closed_at: 1.day.from_now,
-    state: Petition::PENDING_STATE,
-    creator_attributes: { email: 'charlie.the.creator@example.com' })
+    creator_attributes: { email: 'charlie.the.creator@example.com' }
+  )
 end
 
 Given(/^I have already sponsored the petition(?: with email "(.*?)")?$/) do |email|
@@ -18,8 +16,13 @@ Given(/^I have already sponsored the petition(?: with email "(.*?)")?$/) do |ema
   sponsor = FactoryBot.create(:validated_signature, email: email, sponsor: true, petition: @sponsor_petition)
 end
 
-When(/^a sponsor supports my petition$/) do
-  sponsor_email = FactoryBot.generate(:sponsor_email)
+When(/^(Laura|a sponsor) supports my petition$/) do |who|
+  if who == "Laura"
+    sponsor_email = "laura.the.sponsor@example.com"
+  else
+    sponsor_email = FactoryBot.generate(:sponsor_email)
+  end
+
   steps %{
     When I visit the "sponsor this petition" url I was given
     And I fill in "Name" with "Anonymous Sponsor"
@@ -34,6 +37,15 @@ When(/^a sponsor supports my petition$/) do
   signature = @sponsor_petition.signatures.for_email(sponsor_email).first
   expect(signature).to be_present
   expect(signature).to be_sponsor
+end
+
+When(/^Laura verifies her signature again$/) do
+  deliveries.delete_if { |email| email.to == %w[charlie.the.creator@example.com] }
+
+  steps %{
+    And "laura.the.sponsor@example.com" opens the email with subject "Please confirm your email address"
+    And they click the first link in the email
+  }
 end
 
 Given(/^I only need one more sponsor to support my petition$/) do

--- a/features/step_definitions/sponsor_support_notification_steps.rb
+++ b/features/step_definitions/sponsor_support_notification_steps.rb
@@ -2,12 +2,16 @@ Then(/^I should receive a sponsor support notification email$/) do
   step %{"charlie.the.creator@example.com" should receive an email with subject "supported your petition"}
 end
 
+Then(/^I should not receive a sponsor support notification email$/) do
+  step %{"charlie.the.creator@example.com" should receive no email with subject "supported your petition"}
+end
+
 Then(/^I should receive a sponsor threshold notification email$/) do
   step %{"charlie.the.creator@example.com" should receive an email with subject "We’re checking your petition"}
 end
 
-Then(/^I should not receive a sponsor support notification email$/) do
-  step %{"charlie.the.creator@example.com" should receive no email with subject "supported your petition"}
+Then(/^I should not receive a sponsor threshold notification email$/) do
+  step %{"charlie.the.creator@example.com" should receive no email with subject "We’re checking your petition"}
 end
 
 Then(/^the sponsor support notification email should include the countdown to the threshold$/) do

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -50,6 +50,10 @@ After do
   page.driver.options[:headers] = nil
 end
 
+After do
+  ENV["INLINE_UPDATES"] = "true"
+end
+
 Before('@admin') do
   Capybara.app_host = 'https://moderate.petitions.senedd.wales'
   Capybara.default_host = 'https://moderate.petitions.senedd.wales'


### PR DESCRIPTION
This was fixed as part of SeneddCymru/e-petitions#19 so we're adding the test case from alphagov/e-petitions#812 to prevent a regression.