### PR TITLE
Update docker config for latest M1 Macs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+FROM ruby:2.6
+
+ENV BUNDLE_PATH=/bundle
+
+# Install PostgreSQL client
+RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ bullseye-pgdg main' \
+    > /etc/apt/sources.list.d/pgdg.list && \
+    wget -q -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc \
+    | apt-key add - && apt-get update && \
+    apt-get install -y postgresql-client-10
+
+# Install NodeJS
+RUN curl -sL https://deb.nodesource.com/setup_14.x | bash - && \
+    apt-get install -y nodejs
+
+# Install Bundler
+RUN gem install bundler -v 1.17.3
+
+# Install Chromium and Chromium-Driver
+RUN apt-get install -y chromium chromium-driver
+
+# Link chromedriver so the webdrivers gem finds it
+RUN mkdir -p /root/.webdrivers && \
+   ln -nfs /usr/bin/chromedriver /root/.webdrivers/chromedriver && \
+   /usr/bin/chromedriver --version | cut -d ' ' -f 2 | cat > /root/.webdrivers/chromedriver.version
+
+WORKDIR /app
+
+CMD ["/bin/bash"]

--- a/Gemfile
+++ b/Gemfile
@@ -60,7 +60,7 @@ group :test do
   gem 'factory_bot_rails'
   gem 'email_spec'
   gem 'launchy'
-  gem 'webdrivers', '~> 3.8.1'
+  gem 'webdrivers'
   gem 'webmock'
   gem 'rails-controller-testing'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -302,7 +302,7 @@ GEM
     rspec-support (3.10.2)
     ruby-vips (2.1.4)
       ffi (~> 1.12)
-    rubyzip (1.3.0)
+    rubyzip (2.3.2)
     safe_yaml (1.0.5)
     sass (3.7.4)
       sass-listen (~> 4.0.0)
@@ -343,10 +343,10 @@ GEM
       concurrent-ruby (~> 1.0)
     uglifier (4.1.8)
       execjs (>= 0.3.0, < 3)
-    webdrivers (3.8.1)
+    webdrivers (4.7.0)
       nokogiri (~> 1.6)
-      rubyzip (~> 1.0)
-      selenium-webdriver (~> 3.0)
+      rubyzip (>= 1.3.0)
+      selenium-webdriver (> 3.141, < 5.0)
     webmock (3.7.6)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -419,7 +419,7 @@ DEPENDENCIES
   slack-notifier
   textacular
   uglifier
-  webdrivers (~> 3.8.1)
+  webdrivers
   webmock
   whenever
   will_paginate

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ version: "3.7"
 
 x-application: &application
   image: unboxed/epetitions
+  build: .
   entrypoint: ./docker-entrypoint.sh
   environment:
     - DATABASE_URL=postgres://postgres@postgres:5432
@@ -17,7 +18,7 @@ x-application: &application
 
 services:
   postgres:
-    image: postgres:10.7
+    image: postgres:10
     restart: always
     ports:
       - "5432:5432"
@@ -25,7 +26,7 @@ services:
       - db:/var/lib/postgresql/data
 
   memcached:
-    image: memcached:1.5.16
+    image: memcached:1.5
     ports:
       - "11211:11211"
 

--- a/features/support/custom_env.rb
+++ b/features/support/custom_env.rb
@@ -31,17 +31,21 @@ Capybara.register_driver :chrome do |app|
   Capybara::Selenium::Driver.new(app, browser: :chrome, desired_capabilities: capabilities)
 end
 
+chromeArguments = %w[
+  headless
+  allow-insecure-localhost
+  window-size=1280,960
+  proxy-server=127.0.0.1:8443
+]
+
+if File.exist?("/.dockerenv")
+  # Running as root inside Docker
+  chromeArguments += %w[no-sandbox disable-gpu]
+end
+
 Capybara.register_driver :chrome_headless do |app|
   capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
-    chromeOptions: {
-      args: [
-        "headless",
-        "allow-insecure-localhost",
-        "window-size=1280,960",
-        "proxy-server=127.0.0.1:8443"
-      ],
-      w3c: false
-    },
+    chromeOptions: { args: chromeArguments, w3c: false },
     accept_insecure_certs: true
   )
 

--- a/spec/javascripts/support/jasmine.rb
+++ b/spec/javascripts/support/jasmine.rb
@@ -3,10 +3,20 @@ require 'jasmine/runners/selenium'
 Jasmine.configure do |config|
   config.prevent_phantom_js_auto_install = true
 
-  config.runner = lambda { |formatter, jasmine_server_url|
-    options = Selenium::WebDriver::Chrome::Options.new
-    options.headless!
+  chromeArguments = %w[
+    headless
+    allow-insecure-localhost
+    window-size=1280,960
+    proxy-server=127.0.0.1:8443
+  ]
 
+  if File.exist?("/.dockerenv")
+    # Running as root inside Docker
+    chromeArguments += %w[no-sandbox disable-gpu]
+  end
+
+  config.runner = lambda { |formatter, jasmine_server_url|
+    options = Selenium::WebDriver::Chrome::Options.new(args: chromeArguments, w3c: false)
     webdriver = Selenium::WebDriver.for(:chrome, options: options)
     Jasmine::Runners::Selenium.new(formatter, jasmine_server_url, webdriver, 50)
   }


### PR DESCRIPTION
Google doesn't distribute Chrome arm64 binaries for Linux so switch to using Chromium instead which is easier to install.