### PR TITLE
Use the independent colour from Wikipedia as the default colour

### DIFF
--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -35,7 +35,7 @@ class Member < ActiveRecord::Base
   end
 
   def colour
-    PARTY_COLOURS.fetch(party_en)
+    PARTY_COLOURS.fetch(party_en, '#DCDCDC')
   end
 
   private

--- a/spec/models/member_spec.rb
+++ b/spec/models/member_spec.rb
@@ -26,4 +26,30 @@ RSpec.describe Member, type: :model do
     it { is_expected.to have_db_index([:region_id]) }
     it { is_expected.to have_db_index([:constituency_id]).unique }
   end
+
+  describe "#colour" do
+    [
+      ['Welsh Liberal Democrats', '#FDBB30'],
+      ['Welsh Labour and Co-operative Party', '#CC0000'],
+      ['Welsh Labour', '#DC241F'],
+      ['Welsh Conservative Party', '#0087DC'],
+      ['Plaid Cymru', '#008142']
+    ].each do |party, colour|
+      context "when the member's party is '#{party}'" do
+        subject { described_class.new(party: party) }
+
+        it "returns '#{colour}'" do
+          expect(subject.colour).to eq(colour)
+        end
+      end
+    end
+
+    context "when the party is not in the list" do
+      subject { described_class.new(party: "Independent") }
+
+      it "returns '#DCDCDC'" do
+        expect(subject.colour).to eq("#DCDCDC")
+      end
+    end
+  end
 end


### PR DESCRIPTION
Sometimes members can become independent or switch parties to one that's not in our list so in those circumstances return the colour for an independent as defined on Wikipedia[1].

[1]: https://en.wikipedia.org/wiki/Wikipedia:Index_of_United_Kingdom_political_parties_meta_attributes