### PR TITLE
Send out a diversity survey email when petitions are created

### DIFF
--- a/app/jobs/email_creator_about_diversity_survey_email_job.rb
+++ b/app/jobs/email_creator_about_diversity_survey_email_job.rb
@@ -1,0 +1,9 @@
+class EmailCreatorAboutDiversitySurveyEmailJob < NotifyJob
+  self.template = :email_creator_about_diversity_survey
+
+  def personalisation(signature, petition)
+    {
+      creator: signature.name
+    }
+  end
+end

--- a/config/locales/notify.cy-GB.yml
+++ b/config/locales/notify.cy-GB.yml
@@ -3,6 +3,7 @@ cy-GB:
     templates:
       email_confirmation_for_signer: "de60bc30-2d7b-4a71-851f-0ac357af048f"
       email_creator_about_other_business: "86b5dee8-ca22-45be-af00-d74d601e656d"
+      email_creator_about_diversity_survey: "eb7d9389-d6d7-4a6a-bcc9-c5e8b449b34f"
       email_duplicate_signatures: "8d63e92e-1591-420d-a8ec-1df6ecf6a34c"
       email_duplicate_sponsor: "c58cd340-4ba9-43f7-b6f4-7386f7c63260"
       email_signer_about_other_business: "5aa3434b-0530-4655-a2d2-318fd3668568"

--- a/config/locales/notify.en-GB.yml
+++ b/config/locales/notify.en-GB.yml
@@ -3,6 +3,7 @@ en-GB:
     templates:
       email_confirmation_for_signer: "a33e91d1-808a-4a85-abcc-8a4c62266789"
       email_creator_about_other_business: "5b75b985-fc6e-4473-8b51-0958818bea63"
+      email_creator_about_diversity_survey: "f238271b-d186-455a-b2d7-18b17109cb4d"
       email_duplicate_signatures: "e4beb5af-0db1-406b-9c03-a8c8b65f27fd"
       email_duplicate_sponsor: "0f1791a4-55cc-42c2-84d4-d822b35dad55"
       email_signer_about_other_business: "fdc05cf0-81d1-4a28-933c-65b8e10666dd"

--- a/features/step_definitions/signature_steps.rb
+++ b/features/step_definitions/signature_steps.rb
@@ -21,12 +21,12 @@ Then /^I am told to check my inbox to complete signing$/ do
 end
 
 Then(/^(?:I|they|"(.*?)") should be asked to confirm their email address$/) do |address|
-  expect(find_email(address, with_subject: "Please confirm your email address")).to be_present
+  expect(find_email(address, with_subject: "Please confirm your signature")).to be_present
 end
 
 When(/^I confirm my email address(?: again)?$/) do
   steps %Q(
-    And I open the email with subject "Please confirm your email address"
+    And I open the email with subject "Please confirm your signature"
     When I click the first link in the email
   )
 end

--- a/features/step_definitions/sponsor_steps.rb
+++ b/features/step_definitions/sponsor_steps.rb
@@ -31,7 +31,7 @@ When(/^(Laura|a sponsor) supports my petition$/) do |who|
     And I select "Wales" from "Location"
     And I try to sign
     And I say I am happy with my email address
-    And "#{sponsor_email}" opens the email with subject "Please confirm your email address"
+    And "#{sponsor_email}" opens the email with subject "Please confirm your signature"
     And they click the first link in the email
   }
   signature = @sponsor_petition.signatures.for_email(sponsor_email).first
@@ -43,7 +43,7 @@ When(/^Laura verifies her signature again$/) do
   deliveries.delete_if { |email| email.to == %w[charlie.the.creator@example.com] }
 
   steps %{
-    And "laura.the.sponsor@example.com" opens the email with subject "Please confirm your email address"
+    And "laura.the.sponsor@example.com" opens the email with subject "Please confirm your signature"
     And they click the first link in the email
   }
 end
@@ -152,7 +152,7 @@ Then(/^(?:I|"(.*?)") should receive an email explaining the petition I am sponso
   expect(unread_emails_for(address).size).to eq 1
   open_last_email_for(address)
   steps %{
-    Then they should see "Please confirm your email address" in the email subject
+    Then they should see "Please confirm your signature" in the email subject
     And they should see "#{@sponsor_petition.action}" in the email body
     And they should see "#{@sponsor_petition.background}" in the email body
     And they should see "#{@sponsor_petition.additional_details}" in the email body

--- a/spec/controllers/signatures_controller_spec.rb
+++ b/spec/controllers/signatures_controller_spec.rb
@@ -424,7 +424,7 @@ RSpec.describe SignaturesController, type: :controller do
 
         it "sends a confirmation email" do
           expect(last_email_sent).to deliver_to("ted@example.com")
-          expect(last_email_sent).to have_subject(/Please confirm your email address/)
+          expect(last_email_sent).to have_subject(/Please confirm your signature/)
         end
 
         it "redirects to the thank you page" do
@@ -482,7 +482,7 @@ RSpec.describe SignaturesController, type: :controller do
 
         it "re-sends the confirmation email" do
           expect(last_email_sent).to deliver_to("ted@example.com")
-          expect(last_email_sent).to have_subject(/Please confirm your email address/)
+          expect(last_email_sent).to have_subject(/Please confirm your signature/)
         end
 
         it "redirects to the thank you page" do
@@ -511,7 +511,7 @@ RSpec.describe SignaturesController, type: :controller do
 
         it "re-sends the confirmation email" do
           expect(last_email_sent).to deliver_to("ted@example.com")
-          expect(last_email_sent).to have_subject(/Please confirm your email address/)
+          expect(last_email_sent).to have_subject(/Please confirm your signature/)
         end
 
         it "redirects to the thank you page" do

--- a/spec/controllers/sponsors_controller_spec.rb
+++ b/spec/controllers/sponsors_controller_spec.rb
@@ -370,7 +370,7 @@ RSpec.describe SponsorsController, type: :controller do
 
           it "sends a confirmation email" do
             expect(last_email_sent).to deliver_to("ted@example.com")
-            expect(last_email_sent).to have_subject(/Please confirm your email address/)
+            expect(last_email_sent).to have_subject(/Please confirm your signature/)
           end
 
           it "redirects to the thank you page" do
@@ -428,7 +428,7 @@ RSpec.describe SponsorsController, type: :controller do
 
           it "re-sends the confirmation email" do
             expect(last_email_sent).to deliver_to("ted@example.com")
-            expect(last_email_sent).to have_subject(/Please confirm your email address/)
+            expect(last_email_sent).to have_subject(/Please confirm your signature/)
           end
 
           it "redirects to the thank you page" do
@@ -457,7 +457,7 @@ RSpec.describe SponsorsController, type: :controller do
 
           it "re-sends the confirmation email" do
             expect(last_email_sent).to deliver_to("ted@example.com")
-            expect(last_email_sent).to have_subject(/Please confirm your email address/)
+            expect(last_email_sent).to have_subject(/Please confirm your signature/)
           end
 
           it "redirects to the thank you page" do

--- a/spec/fixtures/notify/085e81e4-5ced-4cfe-b142-a03f8b5ffb08.yml
+++ b/spec/fixtures/notify/085e81e4-5ced-4cfe-b142-a03f8b5ffb08.yml
@@ -1,14 +1,18 @@
 id: "085e81e4-5ced-4cfe-b142-a03f8b5ffb08"
 name: "notify_creator_of_debate_scheduled_en"
-subject: "Senedd will debate “((action_en))” | Bydd y Senedd yn trafod “((action_cy))”"
+subject: "The Senedd will debate “((action_en))” | Bydd y Senedd yn trafod “((action_cy))”"
 body: |-
   Dear ((name)),
   
-  Senedd is going to debate your petition – “((action_en))”.
+  The Senedd is going to debate your petition – “((action_en))”.
   
   ((petition_url_en))
   
   The debate is scheduled for ((debate_date_en)).
+  
+  Once it has been published, you’ll be able to find the agenda for the meeting here: https://business.senedd.wales/ieListMeetings.aspx?CommitteeId=401 
+  
+  You’ll be able to watch online on https://www.senedd.tv/
   
   Once the debate has happened, we’ll email you a video and transcript.
   
@@ -28,6 +32,10 @@ body: |-
   ((petition_url_cy))
   
   Mae’r ddadl wedi’i hamserlennu ar gyfer ((debate_date_cy)).
+  
+  Unwaith mae wedi cael ei gyhoeddi, byddwch yn medru dod o hyd i'r agenda ar gyfer y cyfarfod yma: https://busnes.senedd.cymru/ieListMeetings.aspx?CommitteeId=401 
+  
+  Gallwch chi wylio’r ddadl ar-lein ar https://www.senedd.tv/
   
   Ar ôl i’r ddadl ddigwydd, byddwn yn e-bostio fideo a thrawsgrifiad atoch.
   

--- a/spec/fixtures/notify/0e81b36b-9e52-445c-8984-0ee9d89399fe.yml
+++ b/spec/fixtures/notify/0e81b36b-9e52-445c-8984-0ee9d89399fe.yml
@@ -1,6 +1,6 @@
 id: "0e81b36b-9e52-445c-8984-0ee9d89399fe"
 name: "notify_creator_of_debate_scheduled_cy"
-subject: "Bydd y Senedd yn trafod “((action_cy))” | Senedd will debate “((action_en))”"
+subject: "Bydd y Senedd yn trafod “((action_cy))” | The Senedd will debate “((action_en))”"
 body: |-
   Annwyl ((name)),
   
@@ -9,6 +9,10 @@ body: |-
   ((petition_url_cy))
   
   Mae’r ddadl wedi’i hamserlennu ar gyfer ((debate_date_cy)).
+  
+  Unwaith mae wedi cael ei gyhoeddi, byddwch yn medru dod o hyd i'r agenda ar gyfer y cyfarfod yma: https://busnes.senedd.cymru/ieListMeetings.aspx?CommitteeId=401 
+  
+  Gallwch chi wylio’r ddadl ar-lein ar https://www.senedd.tv/ 
   
   Ar ôl i’r ddadl ddigwydd, byddwn yn e-bostio fideo a thrawsgrifiad atoch.
   
@@ -23,11 +27,15 @@ body: |-
   
   Dear ((name)),
   
-  Senedd is going to debate your petition – “((action_en))”.
+  The Senedd is going to debate your petition – “((action_en))”.
   
   ((petition_url_en))
   
   The debate is scheduled for ((debate_date_en)).
+  
+  Once it has been published, you’ll be able to find the agenda for the meeting here: https://business.senedd.wales/ieListMeetings.aspx?CommitteeId=401
+  
+  You’ll be able to watch online on https://www.senedd.tv/ 
   
   Once the debate has happened, we’ll email you a video and transcript.
   

--- a/spec/fixtures/notify/0f912b39-37e2-4de0-886a-28c3e529d139.yml
+++ b/spec/fixtures/notify/0f912b39-37e2-4de0-886a-28c3e529d139.yml
@@ -1,6 +1,6 @@
 id: "0f912b39-37e2-4de0-886a-28c3e529d139"
 name: "petition_and_email_confirmation_for_sponsor_en"
-subject: "Please confirm your email address | Cadarnhewch eich cyfeiriad e-bost"
+subject: "Please confirm your signature | Cadarnhewch eich llofnod"
 body: |-
   Click this link to sign the petition:
   ((url_en))

--- a/spec/fixtures/notify/2d864e9a-275b-41ea-90c9-92b93da8c48a.yml
+++ b/spec/fixtures/notify/2d864e9a-275b-41ea-90c9-92b93da8c48a.yml
@@ -9,15 +9,13 @@ body: |-
   Cliciwch ar y linc i weld eich deiseb a dechrau ei rhannu:
   ((url_cy))
   
-  Mae angen o leiaf ((referral_threshold)) llofnod ar ddeiseb er mwyn i’r Pwyllgor Deisebau ei hystyried. Ni fydd hyn yn digwydd tan ar ôl i’r ddeiseb orffen casglu llofnodion. Rhowch wybod i ni os hoffech newid dyddiad cau eich deiseb.
+  Mae angen o leiaf ((referral_threshold)) llofnod ar ddeiseb er mwyn i’r Pwyllgor Deisebau ei hystyried. Ni fydd hyn yn digwydd tan ar ôl i’r ddeiseb orffen casglu llofnodion.
   
-  Os bydd eich deiseb yn casglu mwy na ((debate_threshold)) llofnod, bydd y Pwyllgor yn ystyried ei chyfeirio ar gyfer dadl yn y Senedd. Wrth wneud hynny, bydd y Pwyllgor yn ystyried nifer o ffactorau gan gynnwys pwnc y ddeiseb a chanran y llofnodion a gasglwyd yng Nghymru.
+  Rhowch wybod i ni os hoffech newid dyddiad cau eich deiseb.
+  
+  Os bydd eich deiseb yn casglu mwy na ((debate_threshold)) llofnod, bydd y Pwyllgor yn ystyried ei chyfeirio ar gyfer dadl yn y Senedd.
   
   Os hoffech gasglu llofnodion ar bapur hefyd, gallwn ddarparu templed ar gais.
-  
-  Os bydd eich deiseb yn casglu ((referral_threshold)) llofnod gallwch drefnu dod i’r Senedd I gyflwyno’ch deiseb yn ffurfiol i’r Pwyllgor. Bydd hwn yn gyfle anffurfiol i drafod eich deiseb gyda’r Cadeirydd ac aelodau eraill y Pwyllgor. Mae’n gwbl ddewisol.
-  
-  Caiff deisebau eu cyflwyno am 12.30 ar ddydd Mawrth a dydd Mercher yn ystod tymor y Senedd ac mae’r broses yn para tua 10-15 munud. Mae pobl yn manteisio ar y cyfleoedd hyn yn gyflym fel arfer, felly cysylltwch â ni cyn gynted â phosibl os hoffech drefnu i gyflwyno deiseb.
   
   Yn olaf, mae croeso i chi gysylltu â ni os bydd angen rhagor o wybodaeth arnoch yn y cyfamser.
   
@@ -34,15 +32,13 @@ body: |-
   Click this link to see your petition and start sharing it:
   ((url_en))
   
-  Petitions need to collect ((referral_threshold)) signatures in order to be considered by the Petitions Committee. This does not happen until after the petition has finished collecting signatures. Please let us know if you would like to change the closing date of your petition.
+  Petitions need to collect ((referral_threshold)) signatures in order to be considered by the Petitions Committee. This does not happen until after the petition has finished collecting signatures. 
   
-  If your petition collects more than ((debate_threshold)) signatures, the Committee will consider referring it for a debate in the Senedd. In doing so, the Committee will consider a range of factors including the subject-matter of the petition and the percentage of signatures gathered from within Wales.
+  Please let us know if you would like to change the closing date of your petition.
+  
+  If your petition collects more than ((debate_threshold)) signatures, the Committee will consider referring it for a debate in the Senedd.
   
   Should you also wish to collect signatures on paper, we can provide a template on request.
-  
-  If your petition collects ((referral_threshold)) signatures you can arrange to come to the Senedd to formally hand in your petition to the Committee. This is an informal opportunity to speak to the Chair and other Members of the Committee about your petition. It is entirely optional.
-  
-  Handovers take place at 12.30pm on Tuesdays and Wednesdays when the Senedd is sitting and last approximately 10 – 15 minutes. These opportunities are often taken up quickly, so please contact us at your earliest convenience if you would like to arrange one.
   
   Finally, should you require any further information in the meantime, please do not hesitate to contact us.
   

--- a/spec/fixtures/notify/4254e36c-b0bc-48ad-9a8c-62d59d16d0ce.yml
+++ b/spec/fixtures/notify/4254e36c-b0bc-48ad-9a8c-62d59d16d0ce.yml
@@ -6,7 +6,7 @@ body: |-
   
   The Senedd debated the petition you signed – “((action_en))”
   
-  ((overview_en))
+  ((overview_en))  The Petitions Committee will consider the petition again in the future, in light of the discussion during the debate.
   
   Watch the debate: ((video_url_en))
   
@@ -29,7 +29,7 @@ body: |-
   
   Trafododd y Senedd y ddeiseb a lofnodwyd gennych - “((action_cy))”
   
-  ((overview_cy))
+  ((overview_cy))  Bydd y Pwyllgor Deisebau yn edrych ar y ddeiseb eto yn y dyfodol, a hynny yng ngoleuni’r drafodaeth yn ystod y ddadl.
   
   Gwyliwch y ddadl: ((video_url_cy))
   

--- a/spec/fixtures/notify/4bda6753-3639-4bad-94a2-b1b1596222b9.yml
+++ b/spec/fixtures/notify/4bda6753-3639-4bad-94a2-b1b1596222b9.yml
@@ -6,7 +6,7 @@ body: |-
   
   Trafododd y Senedd eich deiseb - “((action_cy))”
   
-  ((overview_cy))
+  ((overview_cy))  Bydd y Pwyllgor Deisebau yn edrych ar y ddeiseb eto yn y dyfodol, a hynny yng ngoleuni’r drafodaeth yn ystod y ddadl.
   
   Gwyliwch y ddadl: ((video_url_cy))
   
@@ -29,7 +29,7 @@ body: |-
   
   The Senedd debated your petition – “((action_en))”
   
-  ((overview_en))
+  ((overview_en))  The Petitions Committee will consider the petition again in the future, in light of the discussion during the debate.
   
   Watch the debate: ((video_url_en))
   

--- a/spec/fixtures/notify/50d84545-2438-478d-9838-d61fc2467efd.yml
+++ b/spec/fixtures/notify/50d84545-2438-478d-9838-d61fc2467efd.yml
@@ -8,7 +8,9 @@ body: |-
   
   Cefnogodd ((sponsor)) eich deiseb - “((action))”.
   
-  Mae ((moderation_threshold)) berson wedi cefnogi eich deiseb. Rydym ni’n gwirio’ch deiseb i sicrhau ei bod yn bodloni’r meini prawf ar gyfer deisebau. Os felly, byddwn ni’n cyhoeddi’r ddeiseb ac yn rhoi gwybod i chi. Mae hyn fel arfer yn cymryd hyd at wythnos ond bydd yn cymryd ychydig mwy o amser nag arfer i ni dros gyfnod y Nadolig. Byddwn ni’n gwirio’ch deiseb cyn gynted ag y gallwn.
+  Mae ((moderation_threshold)) berson wedi cefnogi eich deiseb. Rydym ni’n gwirio’ch deiseb i sicrhau ei bod yn bodloni’r meini prawf ar gyfer deisebau. Os felly, byddwn ni’n cyhoeddi’r ddeiseb ac yn rhoi gwybod i chi. Mae hyn fel arfer yn cymryd hyd at wythnos ond bydd yn cymryd ychydig mwy o amser nag arfer i ni dros gyfnod y Nadolig. 
+  
+  Ni fyddwn yn gwirio ac yn cyhoeddi deisebau rhwng 23 Rhagfyr 2020 a 4 Ionawr 2021. Byddwn yn gwirio'ch deiseb cyn gynted ag y gallwn o 4 Ionawr. Ymddiheurwn am unrhyw anghyfleustra.
   
   Dyma wybodaeth am sut rydym ni’n gwirio deisebau cyn eu cyhoeddi:
   ((url_cy))
@@ -25,7 +27,9 @@ body: |-
   
   ((sponsor)) supported your petition – “((action))”.
   
-  ((moderation_threshold)) people have supported your petition. We’re checking your petition to make sure it meets the petition criteria. If it does, we’ll publish it and let you know. This usually takes a week or less but over the Christmas period it will take us a little longer than usual. We’ll check your petition as quickly as we can.
+  ((moderation_threshold)) people have supported your petition. We’re checking your petition to make sure it meets the petition criteria. If it does, we’ll publish it and let you know. This usually takes a week or less but over the Christmas period it will take us a little longer than usual. 
+  
+  We will not be checking and publishing petitions between 23 December 2020 and 4 January 2021. We’ll check your petition as quickly as we can from 4 January. We apologise for any inconvenience.
   
   Find out how we check petitions before we publish them:
   ((url_en))

--- a/spec/fixtures/notify/5920b765-6921-4537-9e01-d8b1338b1071.yml
+++ b/spec/fixtures/notify/5920b765-6921-4537-9e01-d8b1338b1071.yml
@@ -10,7 +10,9 @@ body: |-
   
   Mae angen i ((moderation_threshold)) berson glicio ar y linc a chadarnhau eu cefnogaeth er mwyn i ni gyhoeddi eich deiseb.
   
-  Ar ôl i chi sicrhau’r nifer ofynnol o gefnogwyr, byddwn ni’n gwirio’ch deiseb i sicrhau ei bod yn bodloni’r safonau ar gyfer deisebau. Os felly, byddwn ni’n ei chyhoeddi. Mae hyn fel arfer yn cymryd hyd at wythnos ond bydd yn cymryd ychydig mwy o amser nag arfer i ni dros gyfnod y Pasg. Byddwn ni’n gwirio’ch deiseb cyn gynted ag y gallwn.
+  Ar ôl i chi sicrhau’r nifer ofynnol o gefnogwyr, byddwn ni’n gwirio’ch deiseb i sicrhau ei bod yn bodloni’r safonau ar gyfer deisebau. Os felly, byddwn ni’n ei chyhoeddi. Mae hyn fel arfer yn cymryd hyd at wythnos.
+  
+  Mae'r Pwyllgor Deisebau wedi cyfarfod am y tro olaf cyn Etholiad y Senedd ar 6 Mai 2021. Felly, bydd deisebau newydd bellach yn cael eu hystyried ar ôl yr Etholiad, a byddwn yn oedi o ran casglu llofnodion yn ystod ymgyrch yr Etholiad o 7 Ebrill.
   
   Diolch, 
   Tîm Deisebau
@@ -42,7 +44,9 @@ body: |-
   
   ((moderation_threshold)) people need to click the link and confirm their support for us to publish your petition.
   
-  Once you’ve gained the required number of supporters, we’ll check your petition to make sure it meets the petition standards. If it does we’ll publish it. This usually takes a week or less but over the Easter period it will take us a little longer than usual. We’ll check your petition as quickly as we can.
+  Once you’ve gained the required number of supporters, we’ll check your petition to make sure it meets the petition standards. If it does we’ll publish it. This usually takes a week or less.
+  
+  The Petitions Committee has met for the final time before the Senedd election on 6 May 2021. Therefore, new petitions will now be considered following the election and signature collection will be paused during the election campaign from 7 April.
   
   Thanks, 
   The Petitions team

--- a/spec/fixtures/notify/61cd5971-7bc7-4a1e-b30b-d799a36bff5c.yml
+++ b/spec/fixtures/notify/61cd5971-7bc7-4a1e-b30b-d799a36bff5c.yml
@@ -6,7 +6,7 @@ body: |-
   
   Trafododd y Senedd y ddeiseb a lofnodwyd gennych - “((action_cy))”
   
-  ((overview_cy))
+  ((overview_cy))  Bydd y Pwyllgor Deisebau yn edrych ar y ddeiseb eto yn y dyfodol, a hynny yng ngoleuni’r drafodaeth yn ystod y ddadl.
   
   Gwyliwch y ddadl: ((video_url_cy))
   
@@ -29,7 +29,7 @@ body: |-
   
   The Senedd debated the petition you signed – “((action_en))”
   
-  ((overview_en))
+  ((overview_en))  The Petitions Committee will consider the petition again in the future, in light of the discussion during the debate.
   
   Watch the debate: ((video_url_en))
   

--- a/spec/fixtures/notify/6c9730a2-e31d-4c15-9c05-e96ef5cb8ff4.yml
+++ b/spec/fixtures/notify/6c9730a2-e31d-4c15-9c05-e96ef5cb8ff4.yml
@@ -10,7 +10,11 @@ body: |-
   
   Mae angen i ((moderation_threshold)) berson glicio ar y linc a chadarnhau eu cefnogaeth er mwyn i ni gyhoeddi eich deiseb.
   
-  Ar ôl i chi sicrhau’r nifer ofynnol o gefnogwyr, byddwn ni’n gwirio’ch deiseb i sicrhau ei bod yn bodloni’r meini prawf ar gyfer deisebau. Os felly, byddwn ni’n cyhoeddi’r ddeiseb ac yn rhoi gwybod i chi. Mae hyn fel arfer yn cymryd hyd at wythnos ond bydd yn cymryd ychydig mwy o amser nag arfer i ni dros gyfnod y Nadolig. Byddwn ni’n gwirio’ch deiseb cyn gynted ag y gallwn.
+  Ar ôl i chi sicrhau’r nifer ofynnol o gefnogwyr, byddwn ni’n gwirio’ch deiseb i sicrhau ei bod yn bodloni’r meini prawf ar gyfer deisebau. Os felly, byddwn ni’n cyhoeddi’r ddeiseb ac yn rhoi gwybod i chi. Mae hyn fel arfer yn cymryd hyd at wythnos ond bydd yn cymryd ychydig mwy o amser nag arfer i ni dros gyfnod y Nadolig. 
+  
+  Ni fyddwn yn gwirio ac yn cyhoeddi deisebau rhwng 23 Rhagfyr 2020 a 4 Ionawr 2021. Byddwn yn gwirio'ch deiseb cyn gynted ag y gallwn o 4 Ionawr.
+  
+  Ymddiheurwn am unrhyw anghyfleustra.
   
   Diolch, 
   Tîm Deisebau
@@ -42,7 +46,11 @@ body: |-
   
   ((moderation_threshold)) people need to click the link and confirm their support for us to publish your petition.
   
-  Once you’ve gained the required number of supporters, we’ll check your petition to make sure it meets the petition criteria. If it does we’ll publish it and let you know. This usually takes a week or less but over the Christmas period it will take us a little longer than usual. We’ll check your petition as quickly as we can.
+  Once you’ve gained the required number of supporters, we’ll check your petition to make sure it meets the petition criteria. If it does we’ll publish it and let you know. This usually takes a week or less but over the Christmas period it will take us a little longer than usual. 
+  
+  We will not be checking and publishing petitions between 23 December 2020 and 4 January 2021. We’ll check your petition as quickly as we can from 4 January. 
+  
+  We apologise for any inconvenience.
   
   Thanks, 
   The Petitions team

--- a/spec/fixtures/notify/6fbe2afa-0ee5-4dec-adab-1a7518cbee33.yml
+++ b/spec/fixtures/notify/6fbe2afa-0ee5-4dec-adab-1a7518cbee33.yml
@@ -8,7 +8,9 @@ body: |-
   
   ((sponsor)) supported your petition – “((action))”.
   
-  ((moderation_threshold)) people have supported your petition. We’re checking your petition to make sure it meets the petition criteria. If it does, we’ll publish it and let you know. This usually takes a week or less but over the Easter period it will take us a little longer than usual. We’ll check your petition as quickly as we can.
+  ((moderation_threshold)) people have supported your petition. We’re checking your petition to make sure it meets the petition criteria. If it does, we’ll publish it and let you know. This usually takes a week or less.
+  
+  The Petitions Committee has met for the final time before the Senedd election on 6 May 2021. Therefore, new petitions will now be considered following the election and signature collection will be paused during the election campaign from 7 April.
   
   Find out how we check petitions before we publish them:
   ((url_en))
@@ -25,7 +27,9 @@ body: |-
   
   Cefnogodd ((sponsor)) eich deiseb - “((action))”.
   
-  Mae ((moderation_threshold)) berson wedi cefnogi eich deiseb. Rydym ni’n gwirio’ch deiseb i sicrhau ei bod yn bodloni’r meini prawf ar gyfer deisebau. Os felly, byddwn ni’n cyhoeddi’r ddeiseb ac yn rhoi gwybod i chi. Mae hyn fel arfer yn cymryd hyd at wythnos ond bydd yn cymryd ychydig mwy o amser nag arfer i ni dros gyfnod y Pasg. Byddwn ni’n gwirio’ch deiseb cyn gynted ag y gallwn.
+  Mae ((moderation_threshold)) berson wedi cefnogi eich deiseb. Rydym ni’n gwirio’ch deiseb i sicrhau ei bod yn bodloni’r meini prawf ar gyfer deisebau. Os felly, byddwn ni’n cyhoeddi’r ddeiseb ac yn rhoi gwybod i chi. Mae hyn fel arfer yn cymryd hyd at wythnos.
+  
+  Mae'r Pwyllgor Deisebau wedi cyfarfod am y tro olaf cyn Etholiad y Senedd ar 6 Mai 2021. Felly, bydd deisebau newydd bellach yn cael eu hystyried ar ôl yr Etholiad, a byddwn yn oedi o ran casglu llofnodion yn ystod ymgyrch yr Etholiad o 7 Ebrill.
   
   Dyma wybodaeth am sut rydym ni’n gwirio deisebau cyn eu cyhoeddi:
   ((url_cy))

--- a/spec/fixtures/notify/824662f6-2cb1-4da8-b65d-6b071c569d0e.yml
+++ b/spec/fixtures/notify/824662f6-2cb1-4da8-b65d-6b071c569d0e.yml
@@ -1,14 +1,18 @@
 id: "824662f6-2cb1-4da8-b65d-6b071c569d0e"
 name: "notify_signer_of_debate_scheduled_en"
-subject: "Senedd will debate “((action_en))” | Bydd y Senedd yn trafod “((action_cy))”"
+subject: "The Senedd will debate “((action_en))” | Bydd y Senedd yn trafod “((action_cy))”"
 body: |-
   Dear ((name)),
   
-  Senedd is going to debate the petition you signed – “((action_en))”.
+  The Senedd is going to debate the petition you signed – “((action_en))”.
   
   ((petition_url_en))
   
   The debate is scheduled for ((debate_date_en)).
+  
+  Once it has been published, you’ll be able to find the agenda for the meeting here: https://business.senedd.wales/ieListMeetings.aspx?CommitteeId=401
+  
+  You’ll be able to watch online on https://www.senedd.tv/
   
   Once the debate has happened, we’ll email you a video and transcript.
   
@@ -28,6 +32,10 @@ body: |-
   ((petition_url_cy))
   
   Mae’r ddadl wedi’i hamserlennu ar gyfer ((debate_date_cy)).
+  
+  Unwaith mae wedi cael ei gyhoeddi, byddwch yn medru dod o hyd i'r agenda ar gyfer y cyfarfod yma: https://busnes.senedd.cymru/ieListMeetings.aspx?CommitteeId=401 
+  
+  Gallwch chi wylio’r ddadl ar-lein ar https://www.senedd.tv/ 
   
   Ar ôl i’r ddadl ddigwydd, byddwn yn e-bostio fideo a thrawsgrifiad atoch.
   

--- a/spec/fixtures/notify/929f4523-ee7d-4895-a9e5-32f9fff0c41a.yml
+++ b/spec/fixtures/notify/929f4523-ee7d-4895-a9e5-32f9fff0c41a.yml
@@ -6,7 +6,7 @@ body: |-
   
   The Senedd debated your petition – “((action_en))”
   
-  ((overview_en))
+  ((overview_en))  The Petitions Committee will consider the petition again in the future, in light of the discussion during the debate.
   
   Watch the debate: ((video_url_en))
   
@@ -29,7 +29,7 @@ body: |-
   
   Trafododd y Senedd eich deiseb - “((action_cy))”
   
-  ((overview_cy))
+  ((overview_cy))  Bydd y Pwyllgor Deisebau yn edrych ar y ddeiseb eto yn y dyfodol, a hynny yng ngoleuni’r drafodaeth yn ystod y ddadl.
   
   Gwyliwch y ddadl: ((video_url_cy))
   

--- a/spec/fixtures/notify/939413df-ec0d-4898-acb2-46a63ea3d42f.yml
+++ b/spec/fixtures/notify/939413df-ec0d-4898-acb2-46a63ea3d42f.yml
@@ -1,6 +1,6 @@
 id: "939413df-ec0d-4898-acb2-46a63ea3d42f"
 name: "notify_signer_of_debate_scheduled_cy"
-subject: "Bydd y Senedd yn trafod “((action_cy))” | Senedd will debate “((action_en))”"
+subject: "Bydd y Senedd yn trafod “((action_cy))” | The Senedd will debate “((action_en))”"
 body: |-
   Annwyl ((name)),
   
@@ -9,6 +9,10 @@ body: |-
   ((petition_url_cy))
   
   Mae’r ddadl wedi’i hamserlennu ar gyfer ((debate_date_cy)).
+  
+  Unwaith mae wedi cael ei gyhoeddi, byddwch yn medru dod o hyd i'r agenda ar gyfer y cyfarfod yma: https://busnes.senedd.cymru/ieListMeetings.aspx?CommitteeId=401 
+  
+  Gallwch chi wylio’r ddadl ar-lein ar https://www.senedd.tv/ 
   
   Ar ôl i’r ddadl ddigwydd, byddwn yn e-bostio fideo a thrawsgrifiad atoch.
   
@@ -23,11 +27,15 @@ body: |-
   
   Dear ((name)),
   
-  Senedd is going to debate the petition you signed – “((action_en))”.
+  The Senedd is going to debate the petition you signed – “((action_en))”.
   
   ((petition_url_en))
   
   The debate is scheduled for ((debate_date_en)).
+  
+  Once it has been published, you’ll be able to find the agenda for the meeting here: https://business.senedd.wales/ieListMeetings.aspx?CommitteeId=401
+  
+  You’ll be able to watch online on https://www.senedd.tv/
   
   Once the debate has happened, we’ll email you a video and transcript.
   

--- a/spec/fixtures/notify/a33e91d1-808a-4a85-abcc-8a4c62266789.yml
+++ b/spec/fixtures/notify/a33e91d1-808a-4a85-abcc-8a4c62266789.yml
@@ -1,6 +1,6 @@
 id: "a33e91d1-808a-4a85-abcc-8a4c62266789"
 name: "email_confirmation_for_signer_en"
-subject: "Please confirm your email address | Cadarnhewch eich cyfeiriad e-bost"
+subject: "Please confirm your signature | Cadarnhewch eich llofnod"
 body: |-
   Click this link to sign the petition:
   

--- a/spec/fixtures/notify/c93ca86b-b508-417c-a4b5-28ec33047b2e.yml
+++ b/spec/fixtures/notify/c93ca86b-b508-417c-a4b5-28ec33047b2e.yml
@@ -1,6 +1,6 @@
 id: "c93ca86b-b508-417c-a4b5-28ec33047b2e"
 name: "gather_sponsors_for_petition_moderation_delay_en"
-subject: "Cam i’w gymryd: Deiseb “((action))” | Action required: Petition “((action))”"
+subject: "Action required: Petition “((action))” | Cam i’w gymryd: Deiseb “((action))”"
 body: |-
   Dear ((creator)),
   

--- a/spec/fixtures/notify/dc337901-65b0-4e76-b1d5-b14b90e7ee3e.yml
+++ b/spec/fixtures/notify/dc337901-65b0-4e76-b1d5-b14b90e7ee3e.yml
@@ -9,15 +9,13 @@ body: |-
   Click this link to see your petition and start sharing it:
   ((url_en))
   
-  Petitions need to collect ((referral_threshold)) signatures in order to be considered by the Petitions Committee. This does not happen until after the petition has finished collecting signatures. Please let us know if you would like to change the closing date of your petition.
+  Petitions need to collect ((referral_threshold)) signatures in order to be considered by the Petitions Committee. This does not happen until after the petition has finished collecting signatures. 
   
-  If your petition collects more than ((debate_threshold)) signatures, the Committee will consider referring it for a debate in the Senedd. In doing so, the Committee will consider a range of factors including the subject-matter of the petition and the percentage of signatures gathered from within Wales.
+  Please let us know if you would like to change the closing date of your petition.
+  
+  If your petition collects more than ((debate_threshold)) signatures, the Committee will consider referring it for a debate in the Senedd. 
   
   Should you also wish to collect signatures on paper, we can provide a template on request.
-  
-  If your petition collects ((referral_threshold)) signatures you can arrange to come to the Senedd to formally hand in your petition to the Committee. This is an informal opportunity to speak to the Chair and other Members of the Committee about your petition. It is entirely optional.
-  
-  Handovers take place at 12.30pm on Tuesdays and Wednesdays when the Senedd is sitting and last approximately 10 – 15 minutes. These opportunities are often taken up quickly, so please contact us at your earliest convenience if you would like to arrange one.
   
   Finally, should you require any further information in the meantime, please do not hesitate to contact us.
   
@@ -34,15 +32,13 @@ body: |-
   Cliciwch ar y linc i weld eich deiseb a dechrau ei rhannu:
   ((url_cy))
   
-  Mae angen o leiaf ((referral_threshold)) llofnod ar ddeiseb er mwyn i’r Pwyllgor Deisebau ei hystyried. Ni fydd hyn yn digwydd tan ar ôl i’r ddeiseb orffen casglu llofnodion. Rhowch wybod i ni os hoffech newid dyddiad cau eich deiseb.
+  Mae angen o leiaf ((referral_threshold)) llofnod ar ddeiseb er mwyn i’r Pwyllgor Deisebau ei hystyried. Ni fydd hyn yn digwydd tan ar ôl i’r ddeiseb orffen casglu llofnodion. 
   
-  Os bydd eich deiseb yn casglu mwy na ((debate_threshold)) llofnod, bydd y Pwyllgor yn ystyried ei chyfeirio ar gyfer dadl yn y Senedd. Wrth wneud hynny, bydd y Pwyllgor yn ystyried nifer o ffactorau gan gynnwys pwnc y ddeiseb a chanran y llofnodion a gasglwyd yng Nghymru.
+  Rhowch wybod i ni os hoffech newid dyddiad cau eich deiseb.
+  
+  Os bydd eich deiseb yn casglu mwy na ((debate_threshold)) llofnod, bydd y Pwyllgor yn ystyried ei chyfeirio ar gyfer dadl yn y Senedd. 
   
   Os hoffech gasglu llofnodion ar bapur hefyd, gallwn ddarparu templed ar gais.
-  
-  Os bydd eich deiseb yn casglu ((referral_threshold)) llofnod gallwch drefnu dod i’r Senedd I gyflwyno’ch deiseb yn ffurfiol i’r Pwyllgor. Bydd hwn yn gyfle anffurfiol i drafod eich deiseb gyda’r Cadeirydd ac aelodau eraill y Pwyllgor. Mae’n gwbl ddewisol.
-  
-  Caiff deisebau eu cyflwyno am 12.30 ar ddydd Mawrth a dydd Mercher yn ystod tymor y Senedd ac mae’r broses yn para tua 10-15 munud. Mae pobl yn manteisio ar y cyfleoedd hyn yn gyflym fel arfer, felly cysylltwch â ni cyn gynted â phosibl os hoffech drefnu i gyflwyno deiseb.
   
   Yn olaf, mae croeso i chi gysylltu â ni os bydd angen rhagor o wybodaeth arnoch yn y cyfamser.
   

--- a/spec/fixtures/notify/de60bc30-2d7b-4a71-851f-0ac357af048f.yml
+++ b/spec/fixtures/notify/de60bc30-2d7b-4a71-851f-0ac357af048f.yml
@@ -1,6 +1,6 @@
 id: "de60bc30-2d7b-4a71-851f-0ac357af048f"
 name: "email_confirmation_for_signer_cy"
-subject: "Cadarnhewch eich cyfeiriad e-bost | Please confirm your email address"
+subject: "Cadarnhewch eich llofnod | Please confirm your signature"
 body: |-
   Cliciwch ar y linc i lofnodi’r ddeiseb:
   

--- a/spec/fixtures/notify/eb7d9389-d6d7-4a6a-bcc9-c5e8b449b34f.yml
+++ b/spec/fixtures/notify/eb7d9389-d6d7-4a6a-bcc9-c5e8b449b34f.yml
@@ -1,0 +1,42 @@
+id: "eb7d9389-d6d7-4a6a-bcc9-c5e8b449b34f"
+name: "Witness Diversity - Cy"
+subject: "Arolwg monitro amrywiaeth pwyllgorau | Committee diversity monitoring survey"
+body: |-
+  Annwyl ((creator))
+  
+  Diolch am gymryd rhan yng ngwaith y Pwyllgor Deisebau wrth creu deiseb.
+  
+  Hoffem eich gwahodd i lenwi'r ffurflen fonitro amrywiaeth fer, ddienw hon. Ni ddylai gymryd mwy na thua phum munud. https://senedd.cymru/FfurflenMonitroAmrywiaeth.
+  
+  #Pam rydym yn monitro amrywiaeth y dystiolaeth a ddaw i law? 
+  
+  Mae sawl ffurf ar amrywiaeth, ac felly mae angen i bwyllgorau’r Senedd glywed gan wahanol bobl, cymunedau, sectorau, grwpiau a sefydliadau – yn enwedig y rhai sy’n cael eu heffeithio gan fater sy’n cael ei ystyried.
+  
+  Rydym yn monitro amrywiaeth tystiolaeth i bwyllgorau er mwyn ein helpu i ddeall a yw hyn yn digwydd a beth y gallai fod y rhwystrau i gymryd rhan.
+  
+  Gallwch ddysgu mwy am ein gwaith monitro amrywiaeth tystiolaeth, gan gynnwys sut y byddwn yn diogelu eich data, ar ein tudalennau gwe https://senedd.cymru/TystiolaethAmrywiol
+  
+  Diolch,
+  Tîm Deisebau
+  Y Senedd
+  
+  ---
+  
+  Dear ((creator))
+  
+  Thank you for taking part in the work of the Petitions Committee by creating a petition.
+  
+  We would like to invite you to fill in this short, anonymous diversity monitoring form. It should take no more than around five minutes.
+  https://senedd.wales/DiversityMonitoringForm
+  
+  #Why are we monitoring evidence diversity?
+  
+  Diversity comes in many forms, so Senedd committees need to hear from different people, communities, sectors, groups and organisations - especially those that are affected by an issue under consideration.
+  
+  We are monitoring the diversity of committee evidence to help us understand if this is happening, and what the barriers to participation might be.
+  
+  You can find out more about our evidence diversity monitoring, including how we will protect your data, on our webpages https://senedd.wales/DiverseEvidence.
+  
+  Thanks,
+  The Petitions team
+  Senedd

--- a/spec/fixtures/notify/ed21ff1d-b718-4cef-9491-451f443f9a1d.yml
+++ b/spec/fixtures/notify/ed21ff1d-b718-4cef-9491-451f443f9a1d.yml
@@ -10,7 +10,9 @@ body: |-
   
   ((moderation_threshold)) people need to click the link and confirm their support for us to publish your petition.
   
-  Once you’ve gained the required number of supporters, we’ll check your petition to make sure it meets the petition standards. If it does we’ll publish it. This usually takes a week or less but over the Easter period it will take us a little longer than usual. We’ll check your petition as quickly as we can.
+  Once you’ve gained the required number of supporters, we’ll check your petition to make sure it meets the petition standards. If it does we’ll publish it. This usually takes a week or less.
+  
+  The Petitions Committee has met for the final time before the Senedd election on 6 May 2021. Therefore, new petitions will now be considered following the election and signature collection will be paused during the election campaign from 7 April.
   
   Thanks, 
   The Petitions team
@@ -42,7 +44,9 @@ body: |-
   
   Mae angen i ((moderation_threshold)) berson glicio ar y linc a chadarnhau eu cefnogaeth er mwyn i ni gyhoeddi eich deiseb.
   
-  Ar ôl i chi sicrhau’r nifer ofynnol o gefnogwyr, byddwn ni’n gwirio’ch deiseb i sicrhau ei bod yn bodloni’r safonau ar gyfer deisebau. Os felly, byddwn ni’n ei chyhoeddi. Mae hyn fel arfer yn cymryd hyd at wythnos ond bydd yn cymryd ychydig mwy o amser nag arfer i ni dros gyfnod y Pasg. Byddwn ni’n gwirio’ch deiseb cyn gynted ag y gallwn.
+  Ar ôl i chi sicrhau’r nifer ofynnol o gefnogwyr, byddwn ni’n gwirio’ch deiseb i sicrhau ei bod yn bodloni’r safonau ar gyfer deisebau. Os felly, byddwn ni’n ei chyhoeddi. Mae hyn fel arfer yn cymryd hyd at wythnos.
+  
+  Mae'r Pwyllgor Deisebau wedi cyfarfod am y tro olaf cyn Etholiad y Senedd ar 6 Mai 2021. Felly, bydd deisebau newydd bellach yn cael eu hystyried ar ôl yr Etholiad, a byddwn yn oedi o ran casglu llofnodion yn ystod ymgyrch yr Etholiad o 7 Ebrill.
   
   Diolch, 
   Tîm Deisebau

--- a/spec/fixtures/notify/f10ca6dd-4f07-479c-a588-a3abbafe2c55.yml
+++ b/spec/fixtures/notify/f10ca6dd-4f07-479c-a588-a3abbafe2c55.yml
@@ -1,6 +1,6 @@
 id: "f10ca6dd-4f07-479c-a588-a3abbafe2c55"
 name: "petition_and_email_confirmation_for_sponsor_cy"
-subject: "Cadarnhewch eich cyfeiriad e-bost | Please confirm your email address"
+subject: "Cadarnhewch eich llofnod | Please confirm your signature"
 body: |-
   Cliciwch ar y linc i lofnodi’r ddeiseb:
   ((url_cy))

--- a/spec/fixtures/notify/f238271b-d186-455a-b2d7-18b17109cb4d.yml
+++ b/spec/fixtures/notify/f238271b-d186-455a-b2d7-18b17109cb4d.yml
@@ -1,0 +1,42 @@
+id: "f238271b-d186-455a-b2d7-18b17109cb4d"
+name: "Witness Diversity - En"
+subject: "Committee diversity monitoring survey  |  Arolwg monitro amrywiaeth pwyllgorau"
+body: |-
+  Dear ((creator))
+  
+  Thank you for taking part in the work of the Petitions Committee by creating a petition.
+  
+  We would like to invite you to fill in this short, anonymous diversity monitoring form. It should take no more than around five minutes.
+  https://senedd.wales/DiversityMonitoringForm
+  
+  #Why are we monitoring evidence diversity?
+  
+  Diversity comes in many forms, so Senedd committees need to hear from different people, communities, sectors, groups and organisations - especially those that are affected by an issue under consideration.
+  
+  We are monitoring the diversity of committee evidence to help us understand if this is happening, and what the barriers to participation might be.
+  
+  You can find out more about our evidence diversity monitoring, including how we will protect your data, on our webpages https://senedd.wales/DiverseEvidence.
+  
+  Thanks,
+  The Petitions team
+  Senedd
+  
+  ---
+  
+  Annwyl ((creator))
+  
+  Diolch am gymryd rhan yng ngwaith y Pwyllgor Deisebau wrth creu deiseb.
+  
+  Hoffem eich gwahodd i lenwi'r ffurflen fonitro amrywiaeth fer, ddienw hon. Ni ddylai gymryd mwy na thua phum munud. https://senedd.cymru/FfurflenMonitroAmrywiaeth.
+  
+  #Pam rydym yn monitro amrywiaeth y dystiolaeth a ddaw i law? 
+  
+  Mae sawl ffurf ar amrywiaeth, ac felly mae angen i bwyllgorau’r Senedd glywed gan wahanol bobl, cymunedau, sectorau, grwpiau a sefydliadau – yn enwedig y rhai sy’n cael eu heffeithio gan fater sy’n cael ei ystyried.
+  
+  Rydym yn monitro amrywiaeth tystiolaeth i bwyllgorau er mwyn ein helpu i ddeall a yw hyn yn digwydd a beth y gallai fod y rhwystrau i gymryd rhan.
+  
+  Gallwch ddysgu mwy am ein gwaith monitro amrywiaeth tystiolaeth, gan gynnwys sut y byddwn yn diogelu eich data, ar ein tudalennau gwe https://senedd.cymru/TystiolaethAmrywiol
+  
+  Diolch,
+  Tîm Deisebau
+  Y Senedd

--- a/spec/fixtures/notify/f6ea7df0-9cb1-4895-941a-183ddd0e79db.yml
+++ b/spec/fixtures/notify/f6ea7df0-9cb1-4895-941a-183ddd0e79db.yml
@@ -8,7 +8,9 @@ body: |-
   
   ((sponsor)) supported your petition – “((action))”.
   
-  ((moderation_threshold)) people have supported your petition. We’re checking your petition to make sure it meets the petition criteria. If it does, we’ll publish it and let you know. This usually takes a week or less but over the Christmas period it will take us a little longer than usual. We’ll check your petition as quickly as we can.
+  ((moderation_threshold)) people have supported your petition. We’re checking your petition to make sure it meets the petition criteria. If it does, we’ll publish it and let you know. This usually takes a week or less but over the Christmas period it will take us a little longer than usual. 
+  
+  We will not be checking and publishing petitions between 23 December 2020 and 4 January 2021. We’ll check your petition as quickly as we can from 4 January. We apologise for any inconvenience. 
   
   Find out how we check petitions before we publish them:
   ((url_en))
@@ -25,7 +27,9 @@ body: |-
   
   Cefnogodd ((sponsor)) eich deiseb - “((action))”.
   
-  Mae ((moderation_threshold)) berson wedi cefnogi eich deiseb. Rydym ni’n gwirio’ch deiseb i sicrhau ei bod yn bodloni’r meini prawf ar gyfer deisebau. Os felly, byddwn ni’n cyhoeddi’r ddeiseb ac yn rhoi gwybod i chi. Mae hyn fel arfer yn cymryd hyd at wythnos ond bydd yn cymryd ychydig mwy o amser nag arfer i ni dros gyfnod y Nadolig. Byddwn ni’n gwirio’ch deiseb cyn gynted ag y gallwn.
+  Mae ((moderation_threshold)) berson wedi cefnogi eich deiseb. Rydym ni’n gwirio’ch deiseb i sicrhau ei bod yn bodloni’r meini prawf ar gyfer deisebau. Os felly, byddwn ni’n cyhoeddi’r ddeiseb ac yn rhoi gwybod i chi. Mae hyn fel arfer yn cymryd hyd at wythnos ond bydd yn cymryd ychydig mwy o amser nag arfer i ni dros gyfnod y Nadolig. 
+  
+  Ni fyddwn yn gwirio ac yn cyhoeddi deisebau rhwng 23 Rhagfyr 2020 a 4 Ionawr 2021. Byddwn yn gwirio'ch deiseb cyn gynted ag y gallwn o 4 Ionawr. Ymddiheurwn am unrhyw anghyfleustra.
   
   Dyma wybodaeth am sut rydym ni’n gwirio deisebau cyn eu cyhoeddi:
   ((url_cy))

--- a/spec/fixtures/notify/f7965a34-6f8e-4aa3-97fe-51e8f465d264.yml
+++ b/spec/fixtures/notify/f7965a34-6f8e-4aa3-97fe-51e8f465d264.yml
@@ -10,7 +10,11 @@ body: |-
   
   ((moderation_threshold)) people need to click the link and confirm their support for us to publish your petition.
   
-  Once you’ve gained the required number of supporters, we’ll check your petition to make sure it meets the petition criteria. If it does we’ll publish it and let you know. This usually takes a week or less but over the Christmas period it will take us a little longer than usual. We’ll check your petition as quickly as we can.
+  Once you’ve gained the required number of supporters, we’ll check your petition to make sure it meets the petition criteria. If it does we’ll publish it and let you know. This usually takes a week or less but over the Christmas period it will take us a little longer than usual.
+  
+  We will not be checking and publishing petitions between 23 December 2020 and 4 January 2021. We’ll check your petition as quickly as we can from 4 January. 
+  
+  We apologise for any inconvenience.
   
   Thanks, 
   The Petitions team
@@ -42,7 +46,11 @@ body: |-
   
   Mae angen i ((moderation_threshold)) berson glicio ar y linc a chadarnhau eu cefnogaeth er mwyn i ni gyhoeddi eich deiseb.
   
-  Ar ôl i chi sicrhau’r nifer ofynnol o gefnogwyr, byddwn ni’n gwirio’ch deiseb i sicrhau ei bod yn bodloni’r meini prawf ar gyfer deisebau. Os felly, byddwn ni’n cyhoeddi’r ddeiseb ac yn rhoi gwybod i chi. Mae hyn fel arfer yn cymryd hyd at wythnos ond bydd yn cymryd ychydig mwy o amser nag arfer i ni dros gyfnod y Nadolig. Byddwn ni’n gwirio’ch deiseb cyn gynted ag y gallwn.
+  Ar ôl i chi sicrhau’r nifer ofynnol o gefnogwyr, byddwn ni’n gwirio’ch deiseb i sicrhau ei bod yn bodloni’r meini prawf ar gyfer deisebau. Os felly, byddwn ni’n cyhoeddi’r ddeiseb ac yn rhoi gwybod i chi. Mae hyn fel arfer yn cymryd hyd at wythnos ond bydd yn cymryd ychydig mwy o amser nag arfer i ni dros gyfnod y Nadolig. 
+  
+  Ni fyddwn yn gwirio ac yn cyhoeddi deisebau rhwng 23 Rhagfyr 2020 a 4 Ionawr 2021. Byddwn yn gwirio'ch deiseb cyn gynted ag y gallwn o 4 Ionawr. 
+  
+  Ymddiheurwn am unrhyw anghyfleustra.
   
   Diolch, 
   Tîm Deisebau

--- a/spec/fixtures/notify/fffa81d1-0625-44a1-af7b-780dd27a7719.yml
+++ b/spec/fixtures/notify/fffa81d1-0625-44a1-af7b-780dd27a7719.yml
@@ -8,7 +8,9 @@ body: |-
   
   Cefnogodd ((sponsor)) eich deiseb - “((action))”.
   
-  Mae ((moderation_threshold)) berson wedi cefnogi eich deiseb. Rydym ni’n gwirio’ch deiseb i sicrhau ei bod yn bodloni’r meini prawf ar gyfer deisebau. Os felly, byddwn ni’n cyhoeddi’r ddeiseb ac yn rhoi gwybod i chi. Mae hyn fel arfer yn cymryd hyd at wythnos ond bydd yn cymryd ychydig mwy o amser nag arfer i ni dros gyfnod y Pasg. Byddwn ni’n gwirio’ch deiseb cyn gynted ag y gallwn.
+  Mae ((moderation_threshold)) berson wedi cefnogi eich deiseb. Rydym ni’n gwirio’ch deiseb i sicrhau ei bod yn bodloni’r meini prawf ar gyfer deisebau. Os felly, byddwn ni’n cyhoeddi’r ddeiseb ac yn rhoi gwybod i chi. Mae hyn fel arfer yn cymryd hyd at wythnos.
+  
+  Mae'r Pwyllgor Deisebau wedi cyfarfod am y tro olaf cyn Etholiad y Senedd ar 6 Mai 2021. Felly, bydd deisebau newydd bellach yn cael eu hystyried ar ôl yr Etholiad, a byddwn yn oedi o ran casglu llofnodion yn ystod ymgyrch yr Etholiad o 7 Ebrill.
   
   Dyma wybodaeth am sut rydym ni’n gwirio deisebau cyn eu cyhoeddi:
   ((url_cy))
@@ -25,7 +27,9 @@ body: |-
   
   ((sponsor)) supported your petition – “((action))”.
   
-  ((moderation_threshold)) people have supported your petition. We’re checking your petition to make sure it meets the petition criteria. If it does, we’ll publish it and let you know. This usually takes a week or less but over the Easter period it will take us a little longer than usual. We’ll check your petition as quickly as we can.
+  ((moderation_threshold)) people have supported your petition. We’re checking your petition to make sure it meets the petition criteria. If it does, we’ll publish it and let you know. This usually takes a week or less.
+  
+  The Petitions Committee has met for the final time before the Senedd election on 6 May 2021. Therefore, new petitions will now be considered following the election and signature collection will be paused during the election campaign from 7 April.
   
   Find out how we check petitions before we publish them:
   ((url_en))

--- a/spec/jobs/notify_job_spec.rb
+++ b/spec/jobs/notify_job_spec.rb
@@ -2877,6 +2877,85 @@ RSpec.describe NotifyJob, type: :job, notify: false do
       end
     end
 
+    describe EmailCreatorAboutDiversitySurveyEmailJob do
+      let(:signature) { petition.creator }
+
+      it_behaves_like "a notify job" do
+        let(:petition) { FactoryBot.create(:referred_petition) }
+        let(:arguments) { [signature] }
+      end
+
+      context "when the petition was created in English" do
+        let(:petition) do
+          FactoryBot.create(
+            :referred_petition,
+            action_en: "Do stuff",
+            background_en: "Because of reasons",
+            additional_details_en: "Here's some more reasons",
+            action_cy: "Gwnewch bethau",
+            background_cy: "Oherwydd rhesymau",
+            additional_details_cy: "Dyma ychydig mwy o resymau",
+            locale: "en-GB",
+            creator_name: "Charlie",
+            creator_email: "charlie@example.com",
+            creator_attributes: {
+              locale: "en-GB"
+            }
+          )
+        end
+
+        it "sends an email via GOV.UK Notify with the English template" do
+          perform_enqueued_jobs do
+            described_class.perform_later(signature)
+          end
+
+          expect(notify_request(
+            email_address: "charlie@example.com",
+            template_id: "f238271b-d186-455a-b2d7-18b17109cb4d",
+            reference: "d85a62b0-efb6-51a2-9087-a10881e6728e",
+            personalisation: {
+              creator: "Charlie"
+            }
+          )).to have_been_made
+        end
+      end
+
+      context "when the petition was created in Welsh" do
+        let(:petition) do
+          FactoryBot.create(
+            :referred_petition,
+            action_en: "Do stuff",
+            background_en: "Because of reasons",
+            additional_details_en: "Here's some more reasons",
+            action_cy: "Gwnewch bethau",
+            background_cy: "Oherwydd rhesymau",
+            additional_details_cy: "Dyma ychydig mwy o resymau",
+            locale: "cy-GB",
+            creator_name: "Charlie",
+            creator_email: "charlie@example.com",
+            creator_attributes: {
+              locale: "cy-GB"
+            }
+          )
+        end
+
+        it "sends an email via GOV.UK Notify with the Welsh template" do
+          perform_enqueued_jobs do
+            described_class.perform_later(signature)
+          end
+
+          expect(notify_request(
+            email_address: "charlie@example.com",
+            template_id: "eb7d9389-d6d7-4a6a-bcc9-c5e8b449b34f",
+            reference: "d85a62b0-efb6-51a2-9087-a10881e6728e",
+            personalisation: {
+              creator: "Charlie"
+            }
+          )).to have_been_made
+        end
+      end
+    end
+
     describe EmailSignerAboutOtherBusinessEmailJob do
       let(:email) do
         FactoryBot.create(


### PR DESCRIPTION
Don't send them out at the same time but give a minimum of a whole day after the gather sponsors email has been sent.