### PR TITLE
Don't process the update if the results are empty

### DIFF
--- a/app/jobs/fetch_members_job.rb
+++ b/app/jobs/fetch_members_job.rb
@@ -26,6 +26,8 @@ class FetchMembersJob < ApplicationJob
   end
 
   def perform
+    return if @translated_members.empty?
+
     Member.transaction do
       Member.update_all(region_id: nil, constituency_id: nil)
 

--- a/app/views/constituencies/index.js.erb
+++ b/app/views/constituencies/index.js.erb
@@ -14,7 +14,10 @@
       properties.totalSignatures = petition.signature_count;
       properties.percentageOfSignatures = properties.signatures / properties.totalSignatures;
       properties.percentageOfPopulation = properties.signatures / properties.population;
-      properties.partyColour = properties.member.colour;
+
+      if (properties.member) {
+        properties.partyColour = properties.member.colour;
+      }
 
       maxSignatures = Math.max(maxSignatures, properties.percentageOfSignatures);
       maxPopulation = Math.max(maxPopulation, properties.percentageOfPopulation);

--- a/spec/jobs/fetch_members_job_spec.rb
+++ b/spec/jobs/fetch_members_job_spec.rb
@@ -170,8 +170,9 @@ RSpec.describe FetchMembersJob, type: :job do
         stub_members_cy_api.to_timeout
       end
 
-      it "doesn't import any members" do
-        expect { described_class.perform_now }.not_to change { Member.count }
+      it "doesn't reset the members" do
+        expect(Member).not_to receive(:update_all).with(region_id: nil, constituency_id: nil)
+        described_class.perform_now
       end
     end
 
@@ -181,8 +182,9 @@ RSpec.describe FetchMembersJob, type: :job do
         stub_members_cy_api.to_return(xml_response(:proxy_authentication_required))
       end
 
-      it "doesn't import any members" do
-        expect { described_class.perform_now }.not_to change { Member.count }
+      it "doesn't reset the members" do
+        expect(Member).not_to receive(:update_all).with(region_id: nil, constituency_id: nil)
+        described_class.perform_now
       end
     end
 
@@ -192,8 +194,9 @@ RSpec.describe FetchMembersJob, type: :job do
         stub_members_cy_api.to_return(xml_response(:not_found))
       end
 
-      it "doesn't import any members" do
-        expect { described_class.perform_now }.not_to change { Member.count }
+      it "doesn't reset the members" do
+        expect(Member).not_to receive(:update_all).with(region_id: nil, constituency_id: nil)
+        described_class.perform_now
       end
     end
 
@@ -203,8 +206,9 @@ RSpec.describe FetchMembersJob, type: :job do
         stub_members_cy_api.to_return(xml_response(:not_acceptable))
       end
 
-      it "doesn't import any members" do
-        expect { described_class.perform_now }.not_to change { Member.count }
+      it "doesn't reset the members" do
+        expect(Member).not_to receive(:update_all).with(region_id: nil, constituency_id: nil)
+        described_class.perform_now
       end
     end
 
@@ -214,8 +218,9 @@ RSpec.describe FetchMembersJob, type: :job do
         stub_members_cy_api.to_return(xml_response(:internal_server_error))
       end
 
-      it "doesn't import any members" do
-        expect { described_class.perform_now }.not_to change { Member.count }
+      it "doesn't reset the members" do
+        expect(Member).not_to receive(:update_all).with(region_id: nil, constituency_id: nil)
+        described_class.perform_now
       end
     end
   end


### PR DESCRIPTION
If we have an empty hash for @translated_members it's likely the API returned an error so just bail without resetting all the region and constituency ids.