### PR TITLE
Lock pg gem to < 1.5 until Rails upgrade

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem 'dotenv-rails', require: 'dotenv/rails-now'
 gem 'rails', '6.1.7.8'
 
 gem 'rake'
-gem 'pg'
+gem 'pg', '< 1.5'
 gem 'authlogic'
 gem 'will_paginate'
 gem 'json'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -437,7 +437,7 @@ DEPENDENCIES
   net-http-persistent
   nokogiri
   notifications-ruby-client
-  pg
+  pg (< 1.5)
   pry
   puma (< 6)
   rails (= 6.1.7.8)


### PR DESCRIPTION
The deprecation warnings are fixed in Rails 7.1.