### PR TITLE
Replace without_instrumentation with ignore_instrumentation_events

### DIFF
--- a/app/jobs/concerns/email_all_petition_signatories.rb
+++ b/app/jobs/concerns/email_all_petition_signatories.rb
@@ -61,7 +61,7 @@ module EmailAllPetitionSignatories
   # Batches the signataries to send emails to in groups of 1000
   # and enqueues a job to do the actual sending
   def enqueue_send_email_jobs(**args)
-    Appsignal.without_instrumentation do
+    Appsignal.ignore_instrumentation_events do
       signatures_to_email.find_each do |signature|
         email_delivery_job_class.perform_later(**args.merge(signature: signature, timestamp_name: timestamp_name))
       end

--- a/app/models/invalidation.rb
+++ b/app/models/invalidation.rb
@@ -174,7 +174,7 @@ class Invalidation < ActiveRecord::Base
       counted_at: Time.current
     )
 
-    Appsignal.without_instrumentation do
+    Appsignal.ignore_instrumentation_events do
       matching_signatures.find_in_batches(batch_size: 100) do |signatures|
         signatures.each do |signature|
           signature.invalidate!(Time.current, id)


### PR DESCRIPTION
The former method has been deprecated by Appsignal.