### PR TITLE
Group updates for the AWS SDK gems

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,13 @@ updates:
     versioning-strategy: increase-if-necessary
     open-pull-requests-limit: 10
     groups:
+      aws:
+        applies-to: version-updates
+        patterns:
+          - "aws-*"
+        update-types:
+          - "minor"
+          - "patch"
       rails:
         applies-to: version-updates
         patterns:


### PR DESCRIPTION
These gems are largely auto-generated from a set of API descriptions and consist of lots of individual gems released at the same time.