### PR TITLE
Fix spec failures for extending deadlines

### DIFF
--- a/spec/jobs/extend_petition_deadlines_job_spec.rb
+++ b/spec/jobs/extend_petition_deadlines_job_spec.rb
@@ -18,16 +18,58 @@ RSpec.describe ExtendPetitionDeadlinesJob, type: :job do
   end
 
   context "when signature collection is disabled" do
-    before do
-      expect(Site).to receive(:signature_collection_disabled?).and_return(true)
+    context "and extending the closing date doesn't cross a DST boundary" do
+      around do |example|
+        travel_to("2026-04-01") { example.run }
+      end
+
+      before do
+        expect(Site).to receive(:signature_collection_disabled?).and_return(true)
+      end
+
+      it "increments the closed_at attribute by 24 hours" do
+        expect {
+          described_class.perform_now
+        }.to change {
+          petition.reload.closed_at
+        }.by(24.hours)
+      end
     end
 
-    it "increments the closed_at attribute by 1 day" do
-      expect {
-        described_class.perform_now
-      }.to change {
-        petition.reload.closed_at
-      }.by(1.day)
+    context "and extending the closing date crosses the autumn DST boundary" do
+      around do |example|
+        travel_to("2026-04-24") { example.run }
+      end
+
+      before do
+        expect(Site).to receive(:signature_collection_disabled?).and_return(true)
+      end
+
+      it "increments the closed_at attribute by 25 hours" do
+        expect {
+          described_class.perform_now
+        }.to change {
+          petition.reload.closed_at
+        }.by(25.hours)
+      end
+    end
+
+    context "and extending the closing date crosses the spring DST boundary" do
+      around do |example|
+        travel_to("2026-09-27") { example.run }
+      end
+
+      before do
+        expect(Site).to receive(:signature_collection_disabled?).and_return(true)
+      end
+
+      it "increments the closed_at attribute by 23 hours" do
+        expect {
+          described_class.perform_now
+        }.to change {
+          petition.reload.closed_at
+        }.by(23.hours)
+      end
     end
   end
 end

--- a/spec/models/petition_spec.rb
+++ b/spec/models/petition_spec.rb
@@ -2869,20 +2869,50 @@ RSpec.describe Petition, type: :model do
   describe "#extend_deadline!" do
     let(:petition) { FactoryBot.create(:open_petition, updated_at: 2.days.ago) }
 
-    it "increments the closed_at attribute by 1 day" do
-      expect {
-        petition.extend_deadline!
-      }.to change {
-        petition.reload.closed_at
-      }.by(1.day)
-    end
-
     it "touches the updated_at timestamp" do
       expect {
         petition.extend_deadline!
       }.to change {
         petition.reload.updated_at
       }.to(be_within(1.second).of(Time.current))
+    end
+
+    context "when extending the closing date doesn't cross a DST boundary" do
+      around do |example|
+        travel_to("2026-04-01") { example.run }
+      end
+
+      it "increments the closed_at attribute by 24 hours" do
+        expect {
+          petition.extend_deadline!
+        }.to change {
+          petition.reload.closed_at
+        }.by(24.hours)
+      end
+    end
+
+    context "when extending the closing date crosses the autumn DST boundary" do
+      it "increments the closed_at attribute by 25 hours" do
+        expect {
+          petition.extend_deadline!
+        }.to change {
+          petition.reload.closed_at
+        }.by(25.hours)
+      end
+    end
+
+    context "and extending the closing date crosses the spring DST boundary" do
+      around do |example|
+        travel_to("2026-09-27") { example.run }
+      end
+
+      it "increments the closed_at attribute by 23 hours" do
+        expect {
+          petition.extend_deadline!
+        }.to change {
+          petition.reload.closed_at
+        }.by(23.hours)
+      end
     end
   end
 


### PR DESCRIPTION
When extending the deadline across a DST boundary the change isn't exactly 24 hours.